### PR TITLE
Update deploy_tre.yml

### DIFF
--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -4,9 +4,9 @@ name: Deploy Azure TRE
 # It also runs on a schedule, serving as the nightly build
 
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    # midnight every day https://crontab.guru/#0_0_*_*_*
-    - cron: "0 0 * * *"
+#  schedule:
+#    # midnight every day https://crontab.guru/#0_0_*_*_*
+#    - cron: "0 0 * * *"
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Remove cron-based deployment, will deploy only on commit or manually

We don't want the CICD pipeline deploying the TRE every night while we're in the pre-alpha stage. Until we have users on the system, we want to be able to shut it down (e.g. over Easter) to save money, then re-deploy when we're ready for it again.