### PR TITLE
Update to Base-ADF porter to ensure the workspace can be deleted

### DIFF
--- a/.github/workflows/cli-package.yml
+++ b/.github/workflows/cli-package.yml
@@ -9,7 +9,7 @@ on:
       environment:
         description: The environment to run this workflow in
         type: environment
-        default: CICD
+        default: test
         required: true
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     # environment is used to access the secrets for Azure credentials
     # to sign in to a container registry to re-use a dev container image as a build cache
-    environment: ${{ inputs.environment || 'CICD'}}
+    environment: ${{ inputs.environment || 'test'}}
 
     steps:
       - name: Checkout (GitHub)

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -35,7 +35,7 @@ jobs:
       e2eTestsCustomSelector: >-
         ${{ (github.event_name == 'push' && 'extended or extended_aad')
         || 'extended or extended_aad or shared_services or airlock' }}
-      environmentName: ${{ github.event.inputs.environment || 'CICD' }}
+      environmentName: ${{ github.event.inputs.environment || 'test' }}
       E2E_TESTS_NUMBER_PROCESSES: 1
       DEVCONTAINER_TAG: 'latest'
     secrets:

--- a/.github/workflows/deploy_tre.yml
+++ b/.github/workflows/deploy_tre.yml
@@ -14,7 +14,7 @@ on:  # yamllint disable-line rule:truthy
       environment:
         description: The environment to run this workflow in
         type: environment
-        default: CICD
+        default: test
         required: true
 
 # This will prevent multiple runs of this entire workflow.

--- a/devops/terraform/bootstrap.sh
+++ b/devops/terraform/bootstrap.sh
@@ -2,6 +2,9 @@
 set -o errexit
 set -o pipefail
 set -o nounset
+set -o xtrace
+
+az account show
 
 # Baseline Azure resources
 echo -e "\n\e[34m»»» 🤖 \e[96mCreating resource group and storage account\e[0m..."

--- a/templates/workspaces/base-adf/porter.yaml
+++ b/templates/workspaces/base-adf/porter.yaml
@@ -230,6 +230,7 @@ upgrade:
         arm_client_id: ${ bundle.credentials.azure_client_id }
         arm_client_secret: ${ bundle.credentials.azure_client_secret }
         arm_tenant_id: ${ bundle.credentials.azure_tenant_id }
+        arm_subscription_id: ${ bundle.credentials.azure_subscription_id}
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }
@@ -296,6 +297,7 @@ uninstall:
         arm_client_id: ${ bundle.credentials.azure_client_id }
         arm_client_secret: ${ bundle.credentials.azure_client_secret }
         arm_tenant_id: ${ bundle.credentials.azure_tenant_id }
+        arm_subscription_id: ${ bundle.credentials.azure_subscription_id}
       backendConfig:
         resource_group_name: ${ bundle.parameters.tfstate_resource_group_name }
         storage_account_name: ${ bundle.parameters.tfstate_storage_account_name }


### PR DESCRIPTION
# Resolves HASH_SIGN_FOLLOWED_BY_ISSUE_NUMBER

## What is being addressed

Currently the Base-ADF could be deployed, but not deleted.

## How is this addressed

- Updated the` porter.yaml` in the base-adf folder to include `arm_subscription_id` across all three actions.

## Testing
Redeployed the base-adf bundle
Created Base-ADF workspace
Deleted Base-ADF workspace sucesffully
