### PR TITLE
added encyprtion at host for user resource  vms

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
@@ -124,6 +124,8 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
+  encryption_at_host_enabled   = true
+
 
   custom_data = base64encode(data.template_file.download_review_data_script.rendered)
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
@@ -124,7 +124,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
-  encryption_at_host_enabled   = true
+  encryption_at_host_enabled = true
 
 
   custom_data = base64encode(data.template_file.download_review_data_script.rendered)

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
@@ -45,6 +45,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
+  encryption_at_host_enabled   = true
 
   custom_data = base64encode(data.template_file.download_review_data_script.rendered)
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
@@ -45,7 +45,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
-  encryption_at_host_enabled   = true
+  encryption_at_host_enabled = true
 
   custom_data = base64encode(data.template_file.download_review_data_script.rendered)
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
@@ -44,6 +44,7 @@ resource "azurerm_linux_virtual_machine" "linuxvm" {
   disable_password_authentication = false
   admin_username                  = random_string.username.result
   admin_password                  = random_password.password.result
+  encryption_at_host_enabled      = true
 
   custom_data = data.template_cloudinit_config.config.rendered
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -45,6 +45,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
+  encryption_at_host_enabled   = true
 
   custom_data = base64encode(templatefile(
     "${path.module}/vm_config.ps1", {

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -45,7 +45,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
   allow_extension_operations = true
   admin_username             = random_string.username.result
   admin_password             = random_password.password.result
-  encryption_at_host_enabled   = true
+  encryption_at_host_enabled = true
 
   custom_data = base64encode(templatefile(
     "${path.module}/vm_config.ps1", {


### PR DESCRIPTION
# Resolves Encryption on the user VMs

**NOTE**
To ensure encryption at host is available it must first be [Registered feature at subscription level](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-cli)


## What is being addressed

Encyoption of all user resource related VMs deployed on TRE.
These include 
- Export VM
- Import VM
- Windows and Linux VMs


## How is this addressed

I used encryption at host method for number of reasons:

1. The encryption is carried out at the VM host - so it is all done by the Azure infrastructure before any of the data is sent to the VM itself.
2. Encyption at host means none of the VM level resources (CPU etc) are not used
3. It was also highlighted that with other method (Azure Disk Encryption) - is [not compatible](https://learn.microsoft.com/en-us/azure/virtual-machines/disk-encryption-overview) with Linux Custom Images so Encryption at Host was a full coverage approach.