### PR TITLE
Tighten guacamole capabilities

### DIFF
--- a/templates/workspace_services/guacamole/parameters.json
+++ b/templates/workspace_services/guacamole/parameters.json
@@ -51,25 +51,6 @@
         "env": "MGMT_STORAGE_ACCOUNT_NAME"
       }
     },
-
-    {
-      "name": "guac_disable_copy",
-      "source": {
-        "env": "GUAC_DISABLE_COPY"
-      }
-    },
-    {
-      "name": "guac_disable_download",
-      "source": {
-        "env": "GUAC_DISABLE_DOWNLOAD"
-      }
-    },
-    {
-      "name": "guac_disable_upload",
-      "source": {
-        "env": "GUAC_DISABLE_UPLOAD"
-      }
-    },
     {
       "name": "guac_disable_paste",
       "source": {

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -41,11 +41,6 @@ parameters:
     type: string
     description: "Resource group containing the devops ACR"
     env: MGMT_RESOURCE_GROUP_NAME
-  - name: guac_disable_copy
-    type: boolean
-    default: true
-    env: GUAC_DISABLE_COPY
-    description: "Guacamole disable copy configuration"
   - name: guac_disable_paste
     type: boolean
     default: false
@@ -66,15 +61,6 @@ parameters:
     default: "/guac-transfer"
     env: GUAC_DRIVE_PATH
     description: "Guacamole drive path configuration"
-  - name: guac_disable_download
-    type: boolean
-    default: true
-    env: GUAC_DISABLE_DOWNLOAD
-    description: "Guacamole disable download configuration"
-  - name: guac_disable_upload
-    type: boolean
-    default: true
-    env: GUAC_DISABLE_UPLOAD
   - name: is_exposed_externally
     type: boolean
     default: true
@@ -137,13 +123,10 @@ install:
         image_tag: ${ bundle.parameters.image_tag }
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
-        guac_disable_copy: ${ bundle.parameters.guac_disable_copy }
         guac_disable_paste: ${ bundle.parameters.guac_disable_paste }
         guac_enable_drive: ${ bundle.parameters.guac_enable_drive }
         guac_drive_name: ${ bundle.parameters.guac_drive_name }
         guac_drive_path: ${ bundle.parameters.guac_drive_path }
-        guac_disable_download: ${ bundle.parameters.guac_disable_download }
-        guac_disable_upload: ${ bundle.parameters.guac_disable_upload }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
@@ -168,13 +151,10 @@ upgrade:
         image_tag: ${ bundle.parameters.image_tag }
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
-        guac_disable_copy: ${ bundle.parameters.guac_disable_copy }
         guac_disable_paste: ${ bundle.parameters.guac_disable_paste }
         guac_enable_drive: ${ bundle.parameters.guac_enable_drive }
         guac_drive_name: ${ bundle.parameters.guac_drive_name }
         guac_drive_path: ${ bundle.parameters.guac_drive_path }
-        guac_disable_download: ${ bundle.parameters.guac_disable_download }
-        guac_disable_upload: ${ bundle.parameters.guac_disable_upload }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }
@@ -199,13 +179,11 @@ uninstall:
         image_tag: ${ bundle.parameters.image_tag }
         mgmt_acr_name: ${ bundle.parameters.mgmt_acr_name }
         mgmt_resource_group_name: ${ bundle.parameters.mgmt_resource_group_name }
-        guac_disable_copy: ${ bundle.parameters.guac_disable_copy }
         guac_disable_paste: ${ bundle.parameters.guac_disable_paste }
         guac_enable_drive: ${ bundle.parameters.guac_enable_drive }
         guac_drive_name: ${ bundle.parameters.guac_drive_name }
+
         guac_drive_path: ${ bundle.parameters.guac_drive_path }
-        guac_disable_download: ${ bundle.parameters.guac_disable_download }
-        guac_disable_upload: ${ bundle.parameters.guac_disable_upload }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         tre_resource_id: ${ bundle.parameters.id }
         aad_authority_url: ${ bundle.parameters.aad_authority_url }

--- a/templates/workspace_services/guacamole/porter.yaml
+++ b/templates/workspace_services/guacamole/porter.yaml
@@ -182,7 +182,6 @@ uninstall:
         guac_disable_paste: ${ bundle.parameters.guac_disable_paste }
         guac_enable_drive: ${ bundle.parameters.guac_enable_drive }
         guac_drive_name: ${ bundle.parameters.guac_drive_name }
-
         guac_drive_path: ${ bundle.parameters.guac_drive_path }
         is_exposed_externally: ${ bundle.parameters.is_exposed_externally }
         tre_resource_id: ${ bundle.parameters.id }

--- a/templates/workspace_services/guacamole/template_schema.json
+++ b/templates/workspace_services/guacamole/template_schema.json
@@ -27,13 +27,6 @@
       "default": "Access Windows and Linux virtual machines via Apache Guacamole. Documentation for using this service can be found here: [https://guacamole.apache.org/doc/gug/using-guacamole.html](https://guacamole.apache.org/doc/gug/using-guacamole.html)",
       "updateable": true
     },
-    "guac_disable_copy": {
-      "$id": "#/properties/guac_disable_copy",
-      "type": "boolean",
-      "title": "Disable 'Copy'",
-      "description": "Disable Copy functionality",
-      "updateable": true
-    },
     "guac_disable_paste": {
       "$id": "#/properties/guac_disable_paste",
       "type": "boolean",
@@ -48,22 +41,6 @@
       "description": "Enable mounted drive",
       "updateable": true,
       "default": false
-    },
-    "guac_disable_download": {
-      "$id": "#/properties/guac_disable_download",
-      "type": "boolean",
-      "title": "Disable files download",
-      "description": "Disable files download",
-      "updateable": true,
-      "default": true
-    },
-    "guac_disable_upload": {
-      "$id": "#/properties/guac_disable_upload",
-      "type": "boolean",
-      "title": "Disable files upload",
-      "description": "Disable files upload",
-      "updateable": true,
-      "default": true
     },
     "is_exposed_externally": {
       "$id": "#/properties/is_exposed_externally",

--- a/templates/workspace_services/guacamole/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/terraform/locals.tf
@@ -23,4 +23,7 @@ locals {
     "AppServiceHTTPLogs", "AppServiceConsoleLogs", "AppServiceAppLogs",
     "AppServiceAuditLogs", "AppServiceIPSecAuditLogs", "AppServicePlatformLogs", "AppServiceAntivirusScanAuditLogs"
   ]
+  guac_disable_copy     = true
+  guac_disable_download = true
+  guac_disable_upload   = true
 }

--- a/templates/workspace_services/guacamole/terraform/variables.tf
+++ b/templates/workspace_services/guacamole/terraform/variables.tf
@@ -26,10 +26,6 @@ variable "image_tag" {
   type        = string
   description = "The Guacamole image tag"
 }
-variable "guac_disable_copy" {
-  type        = bool
-  description = "Disable copy from the Guacamole workspace"
-}
 variable "guac_disable_paste" {
   type        = bool
   description = "Disable paste to the Guacamole workspace"
@@ -45,14 +41,6 @@ variable "guac_drive_name" {
 variable "guac_drive_path" {
   type        = string
   description = "The drive path"
-}
-variable "guac_disable_download" {
-  type        = bool
-  description = "Disable download from the Guacamole workspace"
-}
-variable "guac_disable_upload" {
-  type        = bool
-  description = "Disable upload to the Guacamole workspace"
 }
 variable "is_exposed_externally" {
   type        = bool

--- a/templates/workspace_services/guacamole/terraform/web_app.tf
+++ b/templates/workspace_services/guacamole/terraform/web_app.tf
@@ -50,13 +50,13 @@ resource "azurerm_linux_web_app" "guacamole" {
     APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL = "INFO"
 
     # Guacmole configuration
-    GUAC_DISABLE_COPY     = var.guac_disable_copy
+    GUAC_DISABLE_COPY     = local.guac_disable_copy
     GUAC_DISABLE_PASTE    = var.guac_disable_paste
     GUAC_ENABLE_DRIVE     = var.guac_enable_drive
     GUAC_DRIVE_NAME       = var.guac_drive_name
     GUAC_DRIVE_PATH       = var.guac_drive_path
-    GUAC_DISABLE_DOWNLOAD = var.guac_disable_download
-    GUAC_DISABLE_UPLOAD   = var.guac_disable_upload
+    GUAC_DISABLE_DOWNLOAD = local.guac_disable_download
+    GUAC_DISABLE_UPLOAD   = local.guac_disable_upload
 
     AUDIENCE = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.workspace_client_id.id})"
     ISSUER   = local.issuer


### PR DESCRIPTION
# Resolves #129, #110, bypasses #74.

## What is being addressed

Guacamole currently has options in the UI to allow file upload/download, and to allow copy/paste from the workspace to the outside world.

This PR removes the file upload/download, and allows pasting into the SDE, but not copying out via the clipboard.

## How is this addressed

The menu items are removed from the `template_schema.json` and `porter.yaml` files in the Guacamole service, and the values are hardcoded in the `terraform/locals.tf` file.