### PR TITLE
Deploy custom vms

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -28,10 +28,10 @@ custom:
       install_ui: true
       conda_config: false
     # For information on using custom images, see README.me in the guacamole/user-resources folder
-    # "Custom Image From Gallery":
-    #   source_image_name: your-image
-    #   install_ui: true
-    #   conda_config: true
+    "Custom Ubuntu 22.04 LTS":
+      source_image_name: imgdef-linux-dsvm-rpython
+      install_ui: true
+      conda_config: true
 
 credentials:
   - name: azure_tenant_id

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -16,6 +16,7 @@
       "title": "Linux image",
       "description": "Select Linux image to use for VM",
       "enum": [
+        "Custom Ubuntu 22.04 LTS",
         "Ubuntu 22.04 LTS"
       ]
     },

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/apt_sources_config.yml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/apt_sources_config.yml
@@ -14,7 +14,7 @@ apt:
     deb [trusted=yes] $PRIMARY $RELEASE main restricted universe multiverse
     deb [trusted=yes] $PRIMARY $RELEASE-updates main restricted universe multiverse
     deb [trusted=yes] $SECURITY $RELEASE main restricted universe multiverse
-    deb [signed-by=/etc/apt/trusted.gpg.d/microsoft.gpg] ${nexus_proxy_url}/repository/microsoft-apt/ubuntu/${apt_sku}/prod $RELEASE main
+    deb [signed-by=/etc/apt/trusted.gpg.d/microsoft.gpg] ${nexus_proxy_url}/repository/microsoft-apt/ubuntu/__VERSION_ID__/prod $RELEASE main
     deb [signed-by=/etc/apt/trusted.gpg.d/microsoft.gpg] ${nexus_proxy_url}/repository/microsoft-apt/repos/edge stable main
     deb [signed-by=/etc/apt/trusted.gpg.d/microsoft.gpg] ${nexus_proxy_url}/repository/microsoft-apt/repos/vscode stable main
     deb [signed-by=/etc/apt/trusted.gpg.d/microsoft.gpg] ${nexus_proxy_url}/repository/microsoft-apt/repos/azure-cli $RELEASE main

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/linuxvm.tf
@@ -111,7 +111,6 @@ data "template_file" "vm_config" {
     NEXUS_PROXY_URL       = local.nexus_proxy_url
     CONDA_CONFIG          = local.selected_image.conda_config ? 1 : 0
     VM_USER               = random_string.username.result
-    APT_SKU               = replace(local.apt_sku, ".", "")
   }
 }
 
@@ -133,7 +132,6 @@ data "template_file" "apt_sources_config" {
   template = file("${path.module}/apt_sources_config.yml")
   vars = {
     nexus_proxy_url = local.nexus_proxy_url
-    apt_sku         = local.apt_sku
   }
 }
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
@@ -26,6 +26,6 @@ locals {
   selected_image_source_refs = lookup(local.selected_image, "source_image_reference", null) == null ? [] : [local.selected_image.source_image_reference]
   selected_image_source_id   = lookup(local.selected_image, "source_image_name", null) == null ? null : "${var.image_gallery_id}/images/${local.selected_image.source_image_name}"
   # apt_sku                    = local.selected_image_source_refs[0]["apt_sku"]
-  apt_sku = length(local.selected_image_source_refs) > 0 ? local.selected_image_source_refs[0]["apt_sku"] : "unknown_sku"
+  # apt_sku = length(local.selected_image_source_refs) > 0 ? local.selected_image_source_refs[0]["apt_sku"] : "unknown_sku"
 
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/locals.tf
@@ -25,5 +25,7 @@ locals {
   # selected_image_source_refs is an array to enable easy use of a dynamic block
   selected_image_source_refs = lookup(local.selected_image, "source_image_reference", null) == null ? [] : [local.selected_image.source_image_reference]
   selected_image_source_id   = lookup(local.selected_image, "source_image_name", null) == null ? null : "${var.image_gallery_id}/images/${local.selected_image.source_image_name}"
-  apt_sku                    = local.selected_image_source_refs[0]["apt_sku"]
+  # apt_sku                    = local.selected_image_source_refs[0]["apt_sku"]
+  apt_sku = length(local.selected_image_source_refs) > 0 ? local.selected_image_source_refs[0]["apt_sku"] : "unknown_sku"
+
 }

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/vm_config.sh
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/vm_config.sh
@@ -12,7 +12,7 @@ sudo rm -f /etc/apt/sources.list.d/*
 
 # shellcheck disable=SC1091
 . /etc/os-release
-sed -i "s%unknown_sku%$VERSION_ID%" /etc/apt/sources.list
+sed -i "s%__VERSION_ID__%$VERSION_ID%" /etc/apt/sources.list
 
 # Update apt packages from configured Nexus sources
 echo "init_vm.sh: START"
@@ -102,9 +102,9 @@ if [ "${SHARED_STORAGE_ACCESS}" -eq 1 ]; then
   sudo mount $mntRoot
 fi
 
-set +o errexit
-set +o pipefail
-set +o nounset
+# set +o errexit
+# set +o pipefail
+# set +o nounset
 set -o xtrace
 
 ## Python 3.8 and Jupyter

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -40,9 +40,12 @@ custom:
         version: latest
       conda_config: true
     # For information on using custom images, see README.me in the guacamole/user-resources folder
-    # "Custom Image From Gallery":
-    #   source_image_name: your-image
-    #   conda_config: true
+    "Custom Server 2019 Data Science VM":
+      source_image_name: imgdef-windows11-dsvm-rpython
+      conda_config: true
+    "Custom Windows 10":
+      source_image_name: imgdef-windows10-dsvm-rpython
+      conda_config: true
 
 credentials:
   - name: azure_tenant_id

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -16,9 +16,11 @@
         "title": "Windows image",
         "description": "Select Windows image to use for VM",
         "enum": [
+          "Custom Server 2019 Data Science VM",
+          "Custom Windows 10",
+          "Server 2019 Data Science VM",
           "Windows 10",
-          "Windows 11",
-          "Server 2019 Data Science VM"
+          "Windows 11"
         ]
       },
       "vm_size": {


### PR DESCRIPTION
# Resolves part of #148

## What is being addressed

This update deploys custom VM images from the gallery in the `rg-sde-bh-prod` resource group. The custom Linux and Windows images are there, and the Linux `vm_config.sh` has been updated to handle either vanilla or custom images.

There is no change in the template version. To deploy in an existing SDE, delete your local Docker images for the VMs, delete them also from the Mgmt resource group ACR, and remove the template entry from the CosmosDB. Then build/publish/register, using the Makefile targets.