### PR TITLE
Deploy custom vms

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -32,6 +32,10 @@ custom:
       source_image_name: imgdef-linux-dsvm-rpython
       install_ui: true
       conda_config: true
+    "Custom Ubuntu 24.04 LTS":
+      source_image_name: imgdef-linux24-dsvm-rpython
+      install_ui: true
+      conda_config: true
 
 credentials:
   - name: azure_tenant_id

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -18,15 +18,15 @@ custom:
     "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5  # 2375.82
     "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323.17
   image_options:
-    "Ubuntu 22.04 LTS":
-      source_image_reference:
-        publisher: canonical
-        offer: 0001-com-ubuntu-server-jammy
-        sku: 22_04-lts-gen2
-        version: latest
-        apt_sku: 22.04
-      install_ui: true
-      conda_config: false
+    # "Ubuntu 22.04 LTS":
+    #   source_image_reference:
+    #     publisher: canonical
+    #     offer: 0001-com-ubuntu-server-jammy
+    #     sku: 22_04-lts-gen2
+    #     version: latest
+    #     apt_sku: 22.04
+    #   install_ui: true
+    #   conda_config: false
     # For information on using custom images, see README.me in the guacamole/user-resources folder
     "Custom Ubuntu 22.04 LTS":
       source_image_name: imgdef-linux-dsvm-rpython

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -16,6 +16,7 @@
       "title": "Linux image",
       "description": "Select Linux image to use for VM",
       "enum": [
+        "Custom Ubuntu 24.04 LTS",
         "Custom Ubuntu 22.04 LTS",
         "Ubuntu 22.04 LTS"
       ]

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -17,8 +17,7 @@
       "description": "Select Linux image to use for VM",
       "enum": [
         "Custom Ubuntu 24.04 LTS",
-        "Custom Ubuntu 22.04 LTS",
-        "Ubuntu 22.04 LTS"
+        "Custom Ubuntu 22.04 LTS"
       ]
     },
     "vm_size": {


### PR DESCRIPTION
# Resolves #106, #71, #62 (mostly).

## What is being addressed

Ubuntu 22.04 and 24.04 custom VMs are being used, no longer the vanilla images that need heavy customisation.

N.B. At this point, 24.04 doesn't have RStudio, or Google Chrome. The image needs to be rebuilt with those in it, and these two images, plus the Windows images, need to be checked for consistency across the board.

Also, the customisation script in this repo, `templates/workspace_resources/guacamole/user_resources/guacamole-azure-linuxvm/terraform/vm_config.sh`, can be pruned back hard. It should _only_ have the things relevant to the multi-user aspect of the SDE, all the s/w stuff should be in the custom images.

## How is this addressed

This uses images from the Custom VM Image repository, https://github.com/Barts-Life-Science/TRE-CustomVMs.