### PR TITLE
temporary fix windows storage keys

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
@@ -1,9 +1,13 @@
 Remove-Item -LiteralPath "C:\AzureData" -Force -Recurse
 $ErrorActionPreference = "Stop"
 
-if( ${SharedStorageAccess} -eq 1 )
+if( ${SharedStorageAccess} -eq 1 -And ${StorageAccountKey1} -match "/")
 {
-  $Command = "net use z: \\${StorageAccountFileHost}\${FileShareName} /u:AZURE\${StorageAccountName} ${StorageAccountKey}"
+  $Command = "net use z: \\${StorageAccountFileHost}\${FileShareName} /u:AZURE\${StorageAccountName} ${StorageAccountKey2}"
+  $Command | Out-File  "C:\ProgramData\Start Menu\Programs\StartUp\attach_storage.cmd" -encoding ascii
+} else
+{
+  $Command = "net use z: \\${StorageAccountFileHost}\${FileShareName} /u:AZURE\${StorageAccountName} ${StorageAccountKey1}"
   $Command | Out-File  "C:\ProgramData\Start Menu\Programs\StartUp\attach_storage.cmd" -encoding ascii
 }
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -52,7 +52,8 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
       nexus_proxy_url        = local.nexus_proxy_url
       SharedStorageAccess    = var.shared_storage_access ? 1 : 0
       StorageAccountName     = data.azurerm_storage_account.stg.name
-      StorageAccountKey      = data.azurerm_storage_account.stg.primary_access_key
+      StorageAccountKey1     = data.azurerm_storage_account.stg.primary_access_key
+      StorageAccountkey2     = data.azurerm_storage_account.stg.secondary_access_key
       StorageAccountFileHost = data.azurerm_storage_account.stg.primary_file_host
       FileShareName          = var.shared_storage_access ? data.azurerm_storage_share.shared_storage[0].name : ""
       CondaConfig            = local.selected_image.conda_config ? 1 : 0


### PR DESCRIPTION
Fixes #69 

## What is being addressed

When a randomly-generated shared storage key begins with a '/', Windows interprets this as the start of a string option, not as a value.

## How is this addressed

The simple fix is to check the key to see if it begins with a '/'. If so, use the second key. That reduces the collision rate by a significant amount, but doesn't completely solve the problem. To solve it, the storage account keys need to be checked when the storage account is created, at workspace-creation time.