### PR TITLE
Restore airlock fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,6 @@ terraform.rc
 **/http-client.private.env.json
 
 # vscode
-.vscode
 
 # node
 node_modules

--- a/templates/shared_services/airlock_notifier/app/AirlockNotifier/workflow.json
+++ b/templates/shared_services/airlock_notifier/app/AirlockNotifier/workflow.json
@@ -147,34 +147,35 @@
         "runAfter": {},
         "type": "ParseJson"
       },
-      "Send_Email_with_SMTP": {
+      "Send_an_email_(V2)": {
         "inputs": {
-          "parameters": {
-            "body": "<a href=\"@{parameters('tre_url')}/workspaces/@{body('Parse_JSON')?['data']?['workspace']?['id']}/requests/@{body('Parse_JSON')?['data']?['request']?['id']}\">View the request</a>",
-            "from": "@parameters('smtp_from_email')",
-            "importance": "Normal",
-            "subject": "@variables('message')",
-            "to": "@{join(variables('recipients'), ';')}"
-          },
-          "serviceProviderConfiguration": {
-            "connectionName": "Smtp",
-            "operationId": "sendEmail",
-            "serviceProviderId": "/serviceProviders/Smtp"
-          }
+            "body": {
+                "Body": "<p>@{concat(parameters('tre_url'),'/workspaces/',body('Parse_JSON')?['data']?['workspace']?['id'],'/requests/',body('Parse_JSON')?['data']?['request']?['id'])}</p>",
+                "Importance": "Normal",
+                "Subject": "@variables('message')",
+                "To": "@{join(variables('recipients'),';')}"
+            },
+            "host": {
+                "connection": {
+                    "referenceName": "outlook"
+                }
+            },
+            "method": "post",
+            "path": "/v2/Mail"
         },
         "runAfter": {
-          "Switch_on_request_status": [
-            "Succeeded"
-          ]
+            "Switch_on_request_status": [
+                "SUCCEEDED"
+            ]
         },
-        "type": "ServiceProvider"
-      },
+        "type": "ApiConnection"
+    },
       "Succeeded": {
         "inputs": {
           "runStatus": "Succeeded"
         },
         "runAfter": {
-          "Send_Email_with_SMTP": [
+          "Send_an_email_(V2)": [
             "Succeeded"
           ]
         },

--- a/templates/shared_services/airlock_notifier/app/connections.json
+++ b/templates/shared_services/airlock_notifier/app/connections.json
@@ -35,6 +35,18 @@
         "type": "ManagedServiceIdentity"
       },
       "connectionRuntimeUrl": "@appsetting('smtp_connection_runtime_url')"
-    }
+    },
+      "outlook": {
+          "api": {
+              "id": "/subscriptions/@appsetting('subscription')/providers/Microsoft.Web/locations/uksouth/managedApis/outlook"
+          },
+          "authentication": {
+              "type": "ManagedServiceIdentity"
+          },
+          "connection": {
+              "id": "/subscriptions/@appsetting('subscription')/resourceGroups/@appsetting('resource_group')/providers/Microsoft.Web/connections/outlook"
+          },
+          "connectionRuntimeUrl": "https://dbd1728c4196793d.11.common.logic-uksouth.azure-apihub.net/apim/outlook/3a2261e686234238a0058f766e39e7a4"
+      }
   }
 }

--- a/templates/shared_services/airlock_notifier/porter.yaml
+++ b/templates/shared_services/airlock_notifier/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-airlock-notifier
-version: 0.9.3
+version: 0.9.0
 description: "A shared service notifying on Airlock Operations"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/shared_services/airlock_notifier/porter.yaml
+++ b/templates/shared_services/airlock_notifier/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-airlock-notifier
-version: 0.9.0
+version: 0.9.3
 description: "A shared service notifying on Airlock Operations"
 registry: azuretre
 dockerfile: Dockerfile.tmpl

--- a/templates/shared_services/airlock_notifier/terraform/airlock_notifier.tf
+++ b/templates/shared_services/airlock_notifier/terraform/airlock_notifier.tf
@@ -39,7 +39,7 @@ resource "azurerm_logic_app_standard" "logic_app" {
   version                    = "~4"
   app_settings = {
     "FUNCTIONS_WORKER_RUNTIME"              = "node"
-    "WEBSITE_NODE_DEFAULT_VERSION"          = "~14"
+    "WEBSITE_NODE_DEFAULT_VERSION"          = "~18"
     "serviceBus_connectionString"           = data.azurerm_servicebus_namespace.core.default_primary_connection_string
     "subscription"                          = data.azurerm_subscription.current.subscription_id
     "resource_group"                        = data.azurerm_resource_group.core.name

--- a/templates/shared_services/airlock_notifier/terraform/airlock_notifier.tf
+++ b/templates/shared_services/airlock_notifier/terraform/airlock_notifier.tf
@@ -36,9 +36,10 @@ resource "azurerm_logic_app_standard" "logic_app" {
   storage_account_name       = data.azurerm_storage_account.storage.name
   storage_account_access_key = data.azurerm_storage_account.storage.primary_access_key
   virtual_network_subnet_id  = data.azurerm_subnet.airlock_notification.id
+  version                    = "~4"
   app_settings = {
     "FUNCTIONS_WORKER_RUNTIME"              = "node"
-    "WEBSITE_NODE_DEFAULT_VERSION"          = "~12"
+    "WEBSITE_NODE_DEFAULT_VERSION"          = "~14"
     "serviceBus_connectionString"           = data.azurerm_servicebus_namespace.core.default_primary_connection_string
     "subscription"                          = data.azurerm_subscription.current.subscription_id
     "resource_group"                        = data.azurerm_resource_group.core.name


### PR DESCRIPTION
# Resolves issues with Airlock Notifier using stale versions of runtime and nodejs environments

## What is being addressed

Andrii had fixed the Airlock notifier before, it was using old versions of the runtime environment and of NodeJS. Those changes were lost in the recent merge from upstream, this PR fixes that.

## How is this addressed

- in `templates/shared_services/airlock_notifier/terraform/airlock_notifier.tf`:
- set `WEBSITE_NODE_DEFAULT_VERSION` to `~18`.
- set `version` to `~4` for the `logic_app` resource.