### PR TITLE
Fix case of StorageAccountkey2, and fix logic in PowerShell script

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
@@ -1,7 +1,7 @@
 Remove-Item -LiteralPath "C:\AzureData" -Force -Recurse
 $ErrorActionPreference = "Stop"
 
-if( ${SharedStorageAccess} -eq 1 -And ${StorageAccountKey1} -match "/")
+if( $SharedStorageAccess -eq 1 -and $StorageAccountKey1 -match "/")
 {
   $Command = "net use z: \\${StorageAccountFileHost}\${FileShareName} /u:AZURE\${StorageAccountName} ${StorageAccountKey2}"
   $Command | Out-File  "C:\ProgramData\Start Menu\Programs\StartUp\attach_storage.cmd" -encoding ascii

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -53,7 +53,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
       SharedStorageAccess    = var.shared_storage_access ? 1 : 0
       StorageAccountName     = data.azurerm_storage_account.stg.name
       StorageAccountKey1     = data.azurerm_storage_account.stg.primary_access_key
-      StorageAccountkey2     = data.azurerm_storage_account.stg.secondary_access_key
+      StorageAccountKey2     = data.azurerm_storage_account.stg.secondary_access_key
       StorageAccountFileHost = data.azurerm_storage_account.stg.primary_file_host
       FileShareName          = var.shared_storage_access ? data.azurerm_storage_share.shared_storage[0].name : ""
       CondaConfig            = local.selected_image.conda_config ? 1 : 0


### PR DESCRIPTION
# Resolves #69, again

## What is being addressed

The fix for the storage account key starting with a '/' had two bugs:
1. the `windows.tf` file had `StorageAccountkey2`, instead of `StorageAccountKey2` - wrong case for the 'k', line 52
2. the `vm_config.ps1` script had a bug in the logic for checking the values, in line 4
