### PR TITLE
Update base + ADF workspace to recent azurerm terraform provider

### DIFF
--- a/templates/workspaces/base-adf/terraform/.terraform.lock.hcl
+++ b/templates/workspaces/base-adf/terraform/.terraform.lock.hcl
@@ -42,27 +42,28 @@ provider "registry.terraform.io/hashicorp/azuread" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.73.0"
-  constraints = ">= 3.8.0, >= 3.33.0, 3.73.0"
+  version     = "3.108.0"
+  constraints = ">= 3.8.0, >= 3.33.0, 3.108.0"
   hashes = [
-    "h1:+Z5ZcAQO4e6aWh1N7zX4JqyV/xnDkTRYoCa8pEtNR20=",
-    "zh:068dfe743c9486d09eeaf97eb7817870b932ecb8132b92b8e0d96eadcf51b349",
-    "zh:2a16b0d50feb80919880d32cc12d636c37918bbc9133d7b3ff0d610bac1bee86",
-    "zh:2a77e0deabd3d0f83974125cedca7871add825bf4470688f117a35b6964916cf",
-    "zh:3ade6f3b9483746f168e7daf5223fd65d5d26313616bca37d9117d5b4fba2b66",
-    "zh:44554a1fc5f69a1069bbac3fbe1122794943692f81fc2aabda435740f5e10a67",
-    "zh:69d41ad1073f274548bca763a1ed14813388e5b9b702c15fdc78f2b22b082a09",
-    "zh:8cf5ce91432fc5ed1b9906bca14ab6f0d3b18e78a9f25e00b1de632ae7669645",
-    "zh:b70c294e7d55c3404c40ae18e54113e625ee975e80e3f7d558f3fedde89b038e",
-    "zh:cadab8bc17685a239f45438c555fba156baa709803da55f59cce8c7f1cb70fc1",
-    "zh:cb74e02e1495df938d464e233a41aa5ffab9f0fd79079016d0a630955ce92b6d",
-    "zh:cd7a68c03005116fe40542d312d0236ab5bfdd20a2bb6bdf6398d64945c25ef8",
+    "h1:RIFBFTXz4X48JDHjbQHX4y400ax1/uEzMVFZgX3/z3w=",
+    "zh:2afecf948fd702bc08c87d9114595809d011f99a70a12dbf6bc67a12d0bee5fc",
+    "zh:395b6d1384a579867064e62d49b0b91e15919c33b03ea8b5031c2779bfa16b3d",
+    "zh:3e5594c59b6b02bc6e0f4c3de71aa2ab992494c53725fb3c64d36745f3814ef3",
+    "zh:4613e190609377309f6a4ac44f631c9469efab3ae148dbb09e73718201dc4f42",
+    "zh:624f01cb7604d58100068401bd07ab09a141e7bd318f8214127838cf202e4868",
+    "zh:65709950c9933e38704e2075a2339951e1259a6e882f35d390be36e1844ebc72",
+    "zh:af82657fad4e3a177f2ebb8035b45bda40f8856eb999288533321028794d03e5",
+    "zh:c40b331eba08830d16c0e6795fa7cbf08231073df2cfdb0f34e9d908a915981a",
+    "zh:d6ccd533a0bd984ca7ed1ae860e057e9e2f88468745be9712236d2d240353de4",
+    "zh:f361fd398e8772f8554a010331d161d6f7284a43238fd28bfa7b41795a5538b8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f8c2132c77d35930203ec66f1bf9bbf633a2406e9f7b572ff425d65b8aa8c492",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.2"
+  version     = "3.2.2"
+  constraints = "3.2.2"
   hashes = [
     "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",

--- a/templates/workspaces/base-adf/terraform/azure-monitor/azure-monitor.tf
+++ b/templates/workspaces/base-adf/terraform/azure-monitor/azure-monitor.tf
@@ -136,7 +136,8 @@ resource "azurerm_monitor_private_link_scoped_service" "ampls_app_insights" {
   scope_name          = azapi_resource.ampls_workspace.name
 
   # linked_resource_id  = azurerm_application_insights.workspace.id
-  linked_resource_id = jsondecode(azapi_resource.appinsights.output).id
+  # linked_resource_id = jsondecode(azapi_resource.appinsights.output).id
+  linked_resource_id = replace(jsondecode(azapi_resource.appinsights.output).id, "microsoft.insights", "Microsoft.Insights")
 }
 
 resource "azurerm_private_endpoint" "azure_monitor_private_endpoint" {

--- a/templates/workspaces/base-adf/terraform/providers.tf
+++ b/templates/workspaces/base-adf/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.73.0"
+      version = "=3.108.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
Addendum to PR 168, updating terraform providers

## What is being addressed

The terraform provider for the `base-adf` workspace has been updated.

## How is this addressed

Exactly the same way as for the base workspace: update the `terraform/.terraform.lock.hcl`, `terraform/providers.tf`, and `terraform/azure-monitor/azure-monitor.tf` files