### PR TITLE
Upgrade Nexus VM to larger machine…

### DIFF
--- a/templates/shared_services/sonatype-nexus-vm/porter.yaml
+++ b/templates/shared_services/sonatype-nexus-vm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-sonatype-nexus
-version: 3.0.0
+version: 3.0.1
 description: "A Sonatype Nexus shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/sonatype-nexus-vm/scripts/deploy_nexus_container.sh
+++ b/templates/shared_services/sonatype-nexus-vm/scripts/deploy_nexus_container.sh
@@ -20,7 +20,17 @@ while true; do
   ((docker_pull_timeout--));
 done
 
+# Deduce memory available to Java. Either 3/4 of the system RAM, or a set minimum
+mem_total_mb=$(( $(cat /proc/meminfo | head -1 | awk '{ print $2 }') / 1024 ))
+java_mem=2703
+if [ $mem_total_mb -gt 4096 ]; then
+  java_mem=$(( $mem_total_mb * 3 / 4 ))
+fi
+
+echo "System memory: ${mem_total_mb} MB. Java memory: ${java_mem} MB"
+
 docker run -d -p 80:8081 -p 443:8443 -p 8083:8083 -v /etc/nexus-data:/nexus-data \
+    -e INSTALL4J_ADD_VM_PARAMS="-Xmx${java_mem}m -Xms${java_mem}m" \
     --restart always \
     --name nexus \
     --log-driver local \

--- a/templates/shared_services/sonatype-nexus-vm/scripts/deploy_nexus_container.sh
+++ b/templates/shared_services/sonatype-nexus-vm/scripts/deploy_nexus_container.sh
@@ -21,10 +21,11 @@ while true; do
 done
 
 # Deduce memory available to Java. Either 3/4 of the system RAM, or a set minimum
+# shellcheck disable=SC2002
 mem_total_mb=$(( $(cat /proc/meminfo | head -1 | awk '{ print $2 }') / 1024 ))
 java_mem=2703
 if [ $mem_total_mb -gt 4096 ]; then
-  java_mem=$(( $mem_total_mb * 3 / 4 ))
+  java_mem=$(( mem_total_mb * 3 / 4 ))
 fi
 
 echo "System memory: ${mem_total_mb} MB. Java memory: ${java_mem} MB"

--- a/templates/shared_services/sonatype-nexus-vm/terraform/vm.tf
+++ b/templates/shared_services/sonatype-nexus-vm/terraform/vm.tf
@@ -100,7 +100,7 @@ resource "azurerm_linux_virtual_machine" "nexus" {
   resource_group_name             = local.core_resource_group_name
   location                        = data.azurerm_resource_group.rg.location
   network_interface_ids           = [azurerm_network_interface.nexus.id]
-  size                            = "Standard_B2s"
+  size                            = "Standard_B8ms"
   disable_password_authentication = false
   admin_username                  = "adminuser"
   admin_password                  = random_password.nexus_vm_password.result


### PR DESCRIPTION
Update deployment of Nexus container to set Java VM memory limits based on available RAM.
Bump version number by 0.0.1

# May resolve [Nexus VM runs out of RAM](https://github.com/microsoft/AzureTRE/issues/4074)

## What is being addressed

The Nexus VM can't cope with big bursts of activity. it wedges, and the only fix is to stop and restart from the console. Sometimes that isn't enough, and we have to re-deploy the service.

## How is this addressed

- The Nexus VM is changed from a B2s to a B8ms, with 32 GB RAM
- The Nexus deployment script is updated to deduce how much memory to allocate to the Java VM based on the total VM memory
- The version number is bumped by 0.0.1