### PR TITLE
Feature/add gpu options

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -15,11 +15,11 @@ custom:
     "16 CPU | 64GB RAM": Standard_D16s_v5  #  562
     "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
     "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
-    "6 CPU | 55GB RAM | 1/6 x A10 GPU" : Standard_NV6ads_A10_v5   #  533
-    "12 CPU | 110GB RAM | 1/3 x A10 GPU" : Standard_NV6ads_A10_v5 # 1066
-    "18 CPU | 220GB RAM | 1/2 x A10 GPU" : Standard_NV6ads_A10_v5 # 1772
-    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5       # 2375
-    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5      # 3323
+    "6 CPU | 55GB RAM | 1/6 x A10 GPU": Standard_NV6ads_A10_v5   #  533
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV6ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV6ads_A10_v5 # 1772
+    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5      # 2375
+    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5     # 3323
   image_options:
     # "Ubuntu 22.04 LTS":
     #   source_image_reference:
@@ -65,7 +65,7 @@ parameters:
     env: PARENT_SERVICE_ID
   - name: image_gallery_id
     type: string
-    description: Azure resource ID for the compute image gallery to pull images from (if specifying custom images by name)
+    description: Azure resource ID for the compute image gallery to pull images from (if using custom images)
     default: ""
 
   # the following are added automatically by the resource processor

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -9,14 +9,17 @@ registry: azuretre
 custom:
   # For information on vm_sizes and image_options, see README.me in the guacamole/user-resources folder
   vm_sizes:
-    "2 CPU | 8GB RAM": Standard_D2s_v5    #  73.49
-    "4 CPU | 16GB RAM": Standard_D4s_v5   # 145.26
-    "8 CPU | 32GB RAM": Standard_D8s_v5   # 284.78
-    "16 CPU | 64GB RAM": Standard_D16s_v5 # 562.66
-    "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096.22
-    "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134.68
-    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5  # 2375.82
-    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323.17
+    "2 CPU | 8GB RAM": Standard_D2s_v5     #   73
+    "4 CPU | 16GB RAM": Standard_D4s_v5    #  145
+    "8 CPU | 32GB RAM": Standard_D8s_v5    #  284
+    "16 CPU | 64GB RAM": Standard_D16s_v5  #  562
+    "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
+    "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
+    "6 CPU | 55GB RAM | 1/6 x A10 GPU" : Standard_NV6ads_A10_v5   #  533
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU" : Standard_NV6ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU" : Standard_NV6ads_A10_v5 # 1772
+    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5       # 2375
+    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5      # 3323
   image_options:
     # "Ubuntu 22.04 LTS":
     #   source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -32,6 +32,9 @@
         "16 CPU | 64GB RAM",
         "32 CPU | 128GB RAM",
         "64 CPU | 256GB RAM",
+        "6 CPU | 55GB RAM | 1/6 x A10 GPU",
+        "12 CPU | 110GB RAM | 1/3 x A10 GPU",
+        "18 CPU | 220GB RAM | 1/2 x A10 GPU",
         "36 CPU | 440GB | 1 x A10 GPU",
         "36 CPU | 880GB | 1 x A10 GPU"
       ],

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -15,11 +15,11 @@ custom:
     "16 CPU | 64GB RAM": Standard_D16s_v5  #  562
     "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
     "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
-    "6 CPU | 55GB RAM | 1/6 x A10 GPU" : Standard_NV6ads_A10_v5   #  533
-    "12 CPU | 110GB RAM | 1/3 x A10 GPU" : Standard_NV6ads_A10_v5 # 1066
-    "18 CPU | 220GB RAM | 1/2 x A10 GPU" : Standard_NV6ads_A10_v5 # 1772
-    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5       # 2375
-    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5      # 3323
+    "6 CPU | 55GB RAM | 1/6 x A10 GPU": Standard_NV6ads_A10_v5   #  533
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV6ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV6ads_A10_v5 # 1772
+    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5      # 2375
+    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5     # 3323
   image_options:
     "Windows 10":
       source_image_reference:
@@ -71,7 +71,7 @@ parameters:
     env: PARENT_SERVICE_ID
   - name: image_gallery_id
     type: string
-    description: Azure resource ID for the compute image gallery to pull images from (if specifying custom images by name)
+    description: Azure resource ID for the compute image gallery to pull images from (if using custom images)
     default: ""
   - name: id
     type: string

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -9,14 +9,17 @@ registry: azuretre
 custom:
   # For information on vm_sizes and image_options, see README.me in the guacamole/user-resources folder
   vm_sizes:
-    "2 CPU | 8GB RAM": Standard_D2s_v5    #  73.49
-    "4 CPU | 16GB RAM": Standard_D4s_v5   # 145.26
-    "8 CPU | 32GB RAM": Standard_D8s_v5   # 284.78
-    "16 CPU | 64GB RAM": Standard_D16s_v5 # 562.66
-    "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096.22
-    "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134.68
-    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5  # 2375.82
-    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323.17
+    "2 CPU | 8GB RAM": Standard_D2s_v5     #   73
+    "4 CPU | 16GB RAM": Standard_D4s_v5    #  145
+    "8 CPU | 32GB RAM": Standard_D8s_v5    #  284
+    "16 CPU | 64GB RAM": Standard_D16s_v5  #  562
+    "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
+    "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
+    "6 CPU | 55GB RAM | 1/6 x A10 GPU" : Standard_NV6ads_A10_v5   #  533
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU" : Standard_NV6ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU" : Standard_NV6ads_A10_v5 # 1772
+    "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5       # 2375
+    "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5      # 3323
   image_options:
     "Windows 10":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -35,9 +35,12 @@
           "16 CPU | 64GB RAM",
           "32 CPU | 128GB RAM",
           "64 CPU | 256GB RAM",
+          "6 CPU | 55GB RAM | 1/6 x A10 GPU",
+          "12 CPU | 110GB RAM | 1/3 x A10 GPU",
+          "18 CPU | 220GB RAM | 1/2 x A10 GPU",
           "36 CPU | 440GB | 1 x A10 GPU",
           "36 CPU | 880GB | 1 x A10 GPU"
-          ],
+        ],
         "updateable": true
       },
       "shared_storage_access": {


### PR DESCRIPTION
The current GPU options are very expensive, there are smaller GPU machines with access to 1/6, 1/3, or 1/2 a GPU. These are more suitable for development.

This merge adds the extra VM options to the Guacamole Windows and Linux templates.

