### PR TITLE
Add UI for workspace version selection

### DIFF
--- a/ui/app/package.json
+++ b/ui/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tre-ui",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.35.0",

--- a/ui/app/src/components/root/LeftNav.tsx
+++ b/ui/app/src/components/root/LeftNav.tsx
@@ -29,7 +29,13 @@ export const LeftNav: React.FunctionComponent = () => {
         url: '/shared-services',
         key: 'shared-services',
         icon: 'Puzzle'
-      });
+      },
+      {
+        name: 'Configuration',
+        url: '/configuration',
+        key: 'configuration',
+        icon: 'Settings'
+      })
   }
 
   return (

--- a/ui/app/src/components/root/RootLayout.tsx
+++ b/ui/app/src/components/root/RootLayout.tsx
@@ -17,6 +17,7 @@ import { ExceptionLayout } from '../shared/ExceptionLayout';
 import { AppRolesContext } from '../../contexts/AppRolesContext';
 import { CostsContext } from '../../contexts/CostsContext';
 import config from "../../config.json";
+import { TreAdminConfiguration } from '../versions/TreAdminConfiguration';
 
 export const RootLayout: React.FunctionComponent = () => {
   const [workspaces, setWorkspaces] = useState([] as Array<Workspace>);
@@ -146,6 +147,11 @@ export const RootLayout: React.FunctionComponent = () => {
                   <Route path=":sharedServiceId" element={<SecuredByRole element={<SharedServiceItem />} allowedAppRoles={[RoleName.TREAdmin]} errorString={"You must be a TRE Admin to access this area"}/>} />
                 </Routes>
               } />
+	      <Route path="/configuration/*" element={
+                <Routes>
+		  <Route path="/" element={<SecuredByRole element={<TreAdminConfiguration />} allowedAppRoles={[RoleName.TREAdmin]} errorString={"You must be a TRE Admin to access this area"} />} />
+                 </Routes>
+               } />
             </Routes>
           </Stack.Item>
         </Stack>

--- a/ui/app/src/components/shared/create-update-resource/CreateUpdateResource.tsx
+++ b/ui/app/src/components/shared/create-update-resource/CreateUpdateResource.tsx
@@ -42,6 +42,7 @@ export const CreateUpdateResource: React.FunctionComponent<CreateUpdateResourceP
   const [page, setPage] = useState('selectTemplate' as keyof PageTitle);
   const [selectedTemplate, setTemplate] = useState(props.updateResource?.templateName || '');
   const [deployOperation, setDeployOperation] = useState({} as Operation);
+  const [templateVersion, setTemplateVersion] = useState<string | undefined>(undefined);
   const navigate = useNavigate();
   const apiCall = useAuthApiCall();
   const dispatch = useAppDispatch();
@@ -128,11 +129,14 @@ export const CreateUpdateResource: React.FunctionComponent<CreateUpdateResourceP
   let currentPage;
   switch (page) {
     case 'selectTemplate':
-      currentPage = <SelectTemplate templatesPath={templateListPath} workspaceApplicationIdURI={workspaceApplicationIdURI} onSelectTemplate={selectTemplate} />; break;
+      currentPage = <SelectTemplate setTemplateVersion={setTemplateVersion} templatesPath={templateListPath} workspaceApplicationIdURI={workspaceApplicationIdURI} onSelectTemplate={selectTemplate} />; break;
+
     case 'resourceForm':
       currentPage = <ResourceForm
         templateName={selectedTemplate}
         templatePath={`${templateGetPath}/${selectedTemplate}`}
+        // Uncomment this line when versions are pulling through correctly and not using mocks
+        // templateVersion={templateVersion}
         resourcePath={resourcePath}
         onCreateResource={resourceCreating}
         workspaceApplicationIdURI={props.workspaceApplicationIdURI}

--- a/ui/app/src/components/shared/create-update-resource/ResourceForm.tsx
+++ b/ui/app/src/components/shared/create-update-resource/ResourceForm.tsx
@@ -13,6 +13,7 @@ import { ResourceTemplate, sanitiseTemplateForRJSF } from "../../../models/resou
 interface ResourceFormProps {
   templateName: string,
   templatePath: string,
+  templateVersion?: string,
   resourcePath: string,
   updateResource?: Resource,
   onCreateResource: (operation: Operation) => void,
@@ -30,8 +31,18 @@ export const ResourceForm: React.FunctionComponent<ResourceFormProps> = (props: 
   useEffect(() => {
     const getFullTemplate = async () => {
       try {
-        // Get the full resource template containing the required parameters
-        const templateResponse = (await apiCall(props.updateResource ? `${props.templatePath}?is_update=true&version=${props.updateResource.templateVersion}` : props.templatePath, HttpMethod.Get)) as ResourceTemplate;
+        // Determine if the templatePath includes "workspace-service-templates" and if a templateVersion exists
+        const versionQueryParam = props.templatePath.includes("workspace-service-templates") && props?.templateVersion
+          ? `?version=${props.templateVersion}`
+          : "";
+
+        // Construct the API call with the correct query parameters
+        const templateResponse = (await apiCall(
+          props.updateResource
+            ? `${props.templatePath}?is_update=true&version=${props.updateResource.templateVersion}`
+            : `${props.templatePath}${versionQueryParam}`,
+          HttpMethod.Get
+        )) as ResourceTemplate;
 
         // if it's an update, populate the form with the props that are available in the template
         if (props.updateResource) {

--- a/ui/app/src/components/shared/create-update-resource/SelectTemplate.tsx
+++ b/ui/app/src/components/shared/create-update-resource/SelectTemplate.tsx
@@ -1,4 +1,4 @@
-import { DefaultButton, MessageBar, MessageBarType, Spinner, SpinnerSize, Stack } from "@fluentui/react";
+import { DefaultButton, Dropdown, MessageBar, MessageBarType, Spinner, SpinnerSize, Stack } from "@fluentui/react";
 import { useEffect, useState } from "react";
 import { LoadingState } from "../../../models/loadingState";
 import { HttpMethod, useAuthApiCall } from "../../../hooks/useAuthApiCall";
@@ -8,7 +8,8 @@ import { ExceptionLayout } from "../ExceptionLayout";
 interface SelectTemplateProps {
     templatesPath: string,
     workspaceApplicationIdURI?: string | undefined,
-    onSelectTemplate: (templateName: string) => void
+    onSelectTemplate: (templateName: string) => void,
+    setTemplateVersion?: (templateVersion: string) => void
 }
 
 export const SelectTemplate: React.FunctionComponent<SelectTemplateProps> = (props: SelectTemplateProps) => {
@@ -16,6 +17,7 @@ export const SelectTemplate: React.FunctionComponent<SelectTemplateProps> = (pro
     const [loading, setLoading] = useState(LoadingState.Loading as LoadingState);
     const apiCall = useAuthApiCall();
     const [apiError, setApiError] = useState({} as APIError);
+    const [selectedVersion, setSelectedVersion] = useState<string | undefined>(undefined);
 
     useEffect(() => {
         const getTemplates = async () => {
@@ -23,51 +25,87 @@ export const SelectTemplate: React.FunctionComponent<SelectTemplateProps> = (pro
                 const templatesResponse = await apiCall(props.templatesPath, HttpMethod.Get, props.workspaceApplicationIdURI);
                 setTemplates(templatesResponse.templates);
                 setLoading(LoadingState.Ok);
-            } catch (err: any){
+            } catch (err: any) {
                 err.userMessage = 'Error retrieving templates';
                 setApiError(err);
                 setLoading(LoadingState.Error);
             }
         };
 
-        // Fetch resource templates only if not already fetched
         if (!templates) {
             getTemplates();
         }
     }, [apiCall, props.templatesPath, templates, props.workspaceApplicationIdURI]);
 
+    // Function to generate a mock versions array (1-3 versions)
+    const generateMockVersions = () => {
+        const numVersions = Math.floor(Math.random() * 3) + 1;
+        return Array.from({ length: numVersions }, (_, i) => `0.12.${i + 5}`);
+    };
+
     switch (loading) {
         case LoadingState.Ok:
             return (
-                templates && templates.length > 0 ? <Stack>
-                {
-                    templates.map((template: any, i) => {
-                        return (
-                        <div key={i}>
-                            <h2>{template.title}</h2>
-                            <p>{template.description}</p>
-                            <DefaultButton text="Create" onClick={() => props.onSelectTemplate(template.name)}/>
-                        </div>
-                        )
-                    })
-                }
-                </Stack> : <MessageBar
-                    messageBarType={MessageBarType.info}
-                    isMultiline={true}
-                >
-                    <h3>No templates found</h3>
-                    <p>Looks like there aren't any templates registered for this resource type.</p>
-                </MessageBar>
-            )
-        case LoadingState.Error:
-            return (
-                <ExceptionLayout e={apiError} />
+                templates && templates.length > 0 ? (
+                    <Stack>
+                        {templates.map((template: any, i) => {
+                            const versions = template?.versions?.length > 0
+                                ? template.versions
+                                : generateMockVersions();
+
+                            const versionOptions = versions.map((ver: string) => ({
+                                key: ver,
+                                text: `v${ver}`
+                            }));
+
+                            const defaultVersion = versions[versions.length - 1]; // Select last version as default
+                            const isSingleVersion = versions.length === 1;
+                            const showVersioning = props.templatesPath === "workspace-service-templates" && props.setTemplateVersion;
+
+                            return (
+                                <div key={i}>
+                                    <h2>{template.title}</h2>
+                                    <p>{template.description}</p>
+                                    <Stack horizontal tokens={{ childrenGap: 10 }} verticalAlign="end">
+                                        {showVersioning && (
+                                            <Dropdown
+                                                placeholder="Select a version"
+                                                label="Select a version"
+                                                options={versionOptions}
+                                                selectedKey={selectedVersion ?? defaultVersion}
+                                                disabled={isSingleVersion}
+                                                onChange={(_, option) => setSelectedVersion(option?.key as string)}
+                                                styles={{ dropdown: { width: 250 } }}
+                                            />
+                                        )}
+                                        <DefaultButton
+                                            text="Create"
+                                            onClick={() => {
+                                                props.onSelectTemplate(template.name);
+                                                if (showVersioning) {
+                                                    props.setTemplateVersion?.(selectedVersion ?? defaultVersion);
+                                                }
+                                            }}
+                                        />
+                                    </Stack>
+                                </div>
+                            );
+                        })}
+                    </Stack>
+                ) : (
+                    <MessageBar messageBarType={MessageBarType.info} isMultiline={true}>
+                        <h3>No templates found</h3>
+                        <p>Looks like there aren't any templates registered for this resource type.</p>
+                    </MessageBar>
+                )
             );
+        case LoadingState.Error:
+            return <ExceptionLayout e={apiError} />;
         default:
             return (
                 <div style={{ marginTop: 20 }}>
                     <Spinner label="Loading templates" ariaLive="assertive" labelPosition="top" size={SpinnerSize.large} />
                 </div>
-            )
+            );
     }
-}
+};

--- a/ui/app/src/components/versions/GenericTable.tsx
+++ b/ui/app/src/components/versions/GenericTable.tsx
@@ -1,0 +1,55 @@
+interface TableProps<T> {
+  data: T[];
+  columns: { key: string; name: string; render: (item: T) => JSX.Element }[];
+}
+
+export const GenericTable = <T,>({ data, columns }: TableProps<T>) => {
+  return (
+    <table style={{ width: "auto", borderCollapse: "collapse", fontSize: "16px" }}>
+      <thead>
+        <tr style={{ backgroundColor: "#f3f3f3", textAlign: "left", height: "40px" }}>
+          {columns.map((col, index) => (
+            <th
+              key={col.key}
+              style={{
+                padding: "10px",
+                borderBottom: "2px solid #ccc",
+                borderRight: "1px solid #ddd",
+                textAlign: "center",
+                minWidth: index === 0 ? "max-content" : "6ch",
+                maxWidth: index === 0 ? "250px" : "8ch",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {col.name}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((item, index) => (
+          <tr key={index} style={{ height: "50px", borderBottom: "1px solid #ddd" }}>
+            {columns.map((col, colIndex) => (
+              <td
+                key={col.key}
+                style={{
+                  padding: "10px",
+                  borderRight: "1px solid #ddd",
+                  textAlign: "center",
+                  verticalAlign: "middle",
+                  minWidth: colIndex === 0 ? "max-content" : "6ch",
+                  maxWidth: colIndex === 0 ? "250px" : "8ch",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {col.render(item)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/ui/app/src/components/versions/TreAdminConfiguration.tsx
+++ b/ui/app/src/components/versions/TreAdminConfiguration.tsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useState } from "react";
+import {
+  PrimaryButton,
+  Stack,
+  Dropdown,
+  IDropdownOption,
+  Checkbox,
+  Text,
+} from "@fluentui/react";
+import { HttpMethod, ResultType, useAuthApiCall } from "../../hooks/useAuthApiCall";
+import { ApiEndpoint } from "../../models/apiEndpoints";
+import { GenericTable } from "./GenericTable";
+
+
+interface ServiceVersion {
+  version: string;
+  description: string;
+  enabled: {
+    TRE: boolean;
+    Workspace: boolean;
+  };
+}
+
+interface Service {
+  name: string;
+  title: string;
+  versions: ServiceVersion[];
+}
+
+interface Workspace {
+  id: string;
+  properties: {
+    display_name: string;
+    service_template_versions: Service[];
+  };
+  _etag: string
+}
+
+interface WorkspacesResponse {
+  workspaces: Workspace[];
+}
+
+interface UpdateRequest {
+  workspaceId: string;
+  workspaceEtag: string;
+  payload: {
+    properties: {
+      service_template_versions: Service[];
+    };
+  };
+}
+
+export const TreAdminConfiguration: React.FC = () => {
+  const [services, setServices] = useState<Service[]>([]);
+  const [selectedService, setSelectedService] = useState<Service | undefined>(undefined);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [updatedWorkspaces, setUpdatedWorkspaces] = useState<Record<string, Record<string, Record<string, boolean>>>>({});
+  const [refreshTrigger, setRefreshTrigger] = useState(false);
+  const [updateErrors, setUpdateErrors] = useState<string[]>([]);
+
+
+  const apiCall = useAuthApiCall();
+
+  useEffect(() => {
+    const getWorkspaceVersions = async () => {
+      const response = await apiCall(ApiEndpoint.Workspaces, HttpMethod.Get) as WorkspacesResponse;
+
+      if (!response?.workspaces) {
+        console.error("No workspaces found in API response");
+        return;
+      }
+
+      setWorkspaces(response.workspaces);
+
+      const uniqueServices = Array.from(
+        new Map(
+          response.workspaces.flatMap((ws) =>
+            ws.properties.service_template_versions.map((service) => [`${service.name}-${service.title}`, service])
+          )
+        ).values()
+      );
+
+      setServices(uniqueServices);
+      if (uniqueServices.length > 0) {
+        setSelectedService(uniqueServices[0]);
+      }
+    };
+
+    getWorkspaceVersions();
+  }, [apiCall, refreshTrigger]);
+
+  const handleServiceChange = (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+    const selected = services.find(service => service.name === option?.key);
+    setSelectedService(selected);
+  };
+
+  const handleCheckboxChange = (workspaceId: string, serviceName: string, version: string) => {
+    setUpdatedWorkspaces((prev) => ({
+      ...prev,
+      [workspaceId]: {
+        ...prev[workspaceId],
+        [serviceName]: {
+          ...prev[workspaceId]?.[serviceName],
+          [version]: !prev[workspaceId]?.[serviceName]?.[version],
+        },
+      },
+    }));
+  };
+
+  const allVersions = workspaces.flatMap(ws =>
+    ws.properties.service_template_versions
+      .find(service => service.name === selectedService?.name)?.versions.map(ver => ver.version) || []
+  );
+
+  const uniqueVersions = Array.from(new Set(allVersions));
+
+  const tableData = workspaces.map((ws) => {
+    const service = ws.properties.service_template_versions.find(
+      (s) => s.name === selectedService?.name
+    );
+
+    return {
+      name: ws.properties.display_name,
+      ...Object.fromEntries(
+        uniqueVersions.map((ver) => {
+          const existingVersion = service?.versions.find((v) => v.version === ver);
+          const defaultChecked = existingVersion?.enabled?.TRE ?? false;
+
+          return [
+            ver,
+            <Checkbox
+              key={ver}
+              checked={updatedWorkspaces[ws.id]?.[selectedService?.name!]?.[ver] ?? defaultChecked}
+              onChange={() => handleCheckboxChange(ws.id, selectedService?.name!, ver)}
+            />,
+          ];
+        })
+      ),
+    };
+  });
+
+  const tableColumns = [
+    { key: "name", name: "Workspace Name", render: (item: any) => <Text>{item.name}</Text> },
+    ...uniqueVersions.map(ver => ({
+      key: ver,
+      name: `v${ver}`,
+      render: (item: any) => item[ver]
+    })),
+  ];
+
+
+
+  const handleSaveChanges = async () => {
+    const servicesList = services
+
+    const updatedRequests = Object.entries(updatedWorkspaces).map(([workspaceId, services]) => {
+      const workspace = workspaces.find(ws => ws.id === workspaceId);
+      if (!workspace) return null;
+
+      const existingServices = workspace.properties.service_template_versions.length > 0
+        ? workspace.properties.service_template_versions
+        : servicesList
+
+      const updatedServiceTemplateVersions = existingServices.map(service => {
+        if (services[service.name]) {
+          return {
+            ...service,
+            versions: service.versions.map(version => ({
+              ...version,
+              enabled: {
+                ...version.enabled,
+                TRE: services[service.name][version.version] ?? version.enabled.TRE,
+              },
+            })),
+          };
+        }
+        return service;
+      });
+
+      return {
+        workspaceId,
+        workspaceEtag: workspace._etag,
+        payload: {
+          properties: {
+            service_template_versions: updatedServiceTemplateVersions,
+          },
+        },
+      };
+    }).filter(Boolean) as UpdateRequest[]
+
+    const failedWorkspaces: string[] = [];
+
+
+    // Perform PATCH requests
+    for (const update of updatedRequests) {
+      try {
+        await apiCall(
+          `${ApiEndpoint.Workspaces}/${update.workspaceId}`,
+          HttpMethod.Patch,
+          update.workspaceId,
+          update.payload,
+          ResultType.JSON,
+          undefined,
+          undefined,
+          update.workspaceEtag
+        );
+        console.log(`Updated workspace ${update.workspaceId} successfully.`);
+      } catch (error) {
+        console.error(`Failed to update workspace ${update.workspaceId}`, error);
+
+        // Find the workspace title from state
+        const failedWorkspace = workspaces.find(ws => ws.id === update.workspaceId);
+        const workspaceTitle = failedWorkspace?.properties.display_name || `Workspace ${update.workspaceId}`;
+
+        failedWorkspaces.push(workspaceTitle);
+      }
+    }
+
+    // If any updates failed, store errors
+    if (failedWorkspaces.length > 0) {
+      setUpdateErrors(failedWorkspaces);
+    } else {
+      setUpdatedWorkspaces({}); // Clear updated state only if successful
+      setRefreshTrigger(prev => !prev);
+    }
+  };
+
+
+
+  return (
+    <Stack tokens={{ childrenGap: 15 }} className="tre-panel">
+      {/* Main Page Title & Subtext */}
+      <Stack>
+        <Text variant="xxLarge" styles={{ root: { fontWeight: "bold" } }}>Version Configuration</Text>
+        <Text variant="medium" styles={{ root: { color: "#666" } }}>
+          Use the dropdown to select a service. Check the versions allowed for each workspace, then click "Save Changes" to apply.
+        </Text>
+      </Stack>
+
+      {/* Dropdown & Service Title */}
+      <Stack>
+        <Dropdown
+          placeholder="Select a service"
+          label="Select a service"
+          options={services.map((s) => ({ key: s.name, text: s.title }))}
+          onChange={handleServiceChange}
+          selectedKey={selectedService?.name}
+          styles={{ dropdown: { width: 250 } }}
+        />
+        {selectedService && (
+          <Text variant="xLarge" styles={{ root: { fontWeight: "bold", marginTop: 10 } }}>
+            {selectedService.title}
+          </Text>
+        )}
+      </Stack>
+
+      {/* Table */}
+      {selectedService && <GenericTable data={tableData} columns={tableColumns} />}
+
+      {/* Save Button */}
+      <Stack.Item>
+        <PrimaryButton
+          iconProps={{ iconName: "Save" }}
+          text="Save Changes"
+          onClick={handleSaveChanges}
+        />
+      </Stack.Item>
+
+      {/* Display Updated Workspaces */}
+      {Object.keys(updatedWorkspaces).length > 0 && (
+        <pre>{JSON.stringify(updatedWorkspaces, null, 2)}</pre>
+      )}
+
+
+      {/* Display Errors if any */}
+      {updateErrors.length > 0 && (
+        <Text variant="small" styles={{ root: { color: "red", marginTop: 10 } }}>
+          Failed to update: {updateErrors.join(", ")}
+        </Text>
+      )}
+    </Stack>
+
+  );
+};


### PR DESCRIPTION
# Resolves #190

## PR Summary: Workspace Service Version Management & UI Enhancements

This PR introduces **admin-level configuration for workspace services**, enabling the selection and management of service versions via a UI-based table. It also integrates **version selection during resource creation**, ensuring services are deployed with the correct versions.

(#190 was marked as resolved by #222 meaning that the reduced scope was done; this PR brings it closer to the original scope.)

---

# What's Left

## API handling of user resource version
- PR #222 doesn't have API handling of the optional version number for resources, once service selection is fully working the TODO comments need implementing.

## Applying Versions When Creating Workspace Services
- A new API endpoint **`{workspace-id}/workspace-service-templates/{workspace_service_name}`** needs to be created to return the workspace enabled `versions` as an **array of strings**, rather than rely on the UI extracting it from the workspace property as previously assumed in PR #222 

- **Expected API Response:**
  ```json
  {
    "name": "tre-service-guacamole",
    "title": "Apache Guacamole - Virtual Desktop Service",
    "description": "Provides remote desktop access via Guacamole",
    ...etc,
    "versions": ["0.12.7", "0.12.8", "0.13.0"]
  }
  ```
- **Steps Remaining in the UI:**
  - Uncomment the `templateVersion` line in `CreateUpdateResource.tsx` so it properly passes the selected version.
  - Remove the **mock versions** logic from `SelectTemplate.tsx` once the API reliably returns versions.

---

## Adding Configuration Ability to Individual Workspaces
> **This feature has not been implemented yet, but here's an overview of the necessary work:**

- **Update** `ui/app/src/components/workspaces/WorkspaceLeftNav.tsx`  
  - Add a new navigation item labeled **Configuration** to the workspace sidebar.

- **Create a new `WorkspaceConfiguration.tsx` component**  
  - Fetch the `service_template_versions` for the selected workspace.
  - Display them in a table similar to `TreAdminConfiguration.tsx`.
  - Allow enabling/disabling service versions per workspace.
  - Include a **Save Changes** button that only updates the `service_template_versions` attribute for the given workspace.

---

# File Changes & Explanations

### **LeftNav.tsx**
This file is responsible for rendering the sidebar navigation in the application.

- Added a **new "Configuration" menu item** to the navigation array.
- This item specifies the route `/configuration`, which allows **TRE Admins** to manage service versions.
- Clicking the item will navigate the user to the corresponding configuration page.

---

### **RootLayout.tsx**
This file is responsible for mapping routes to their corresponding React components.

- Added a new route `/configuration`, which loads `TreAdminConfiguration.tsx`.
- This route is wrapped in `SecuredByRole`, ensuring that **only TRE Admins** can access it.
- This allows TRE Admins to manage service versions securely within the application.

---

### **TreAdminConfiguration.tsx**
This file is responsible for the view displayed at `/configuration`, showing a table with version selection for each workspace.

- **Fetches all workspaces** and their installed service versions.
- **Extracts a list of unique services** across workspaces and displays them in a dropdown.
- **Selecting a service updates the table**, showing all workspaces with checkboxes for each version.
- **Users can toggle checkboxes** to enable/disable versions.
- **Clicking "Save Changes" sends PATCH requests** to update the workspace configuration.
- **After saving**, the component refreshes to reflect updated data.

#### **Key Features in the Component:**

- **Fetching Workspaces & Services**
```tsx
const response = await apiCall(ApiEndpoint.Workspaces, HttpMethod.Get);
setWorkspaces(response.workspaces);
```

- **Tracking Changes in State**
```tsx
setUpdatedWorkspaces((prev) => ({
  ...prev,
  [workspaceId]: {
    ...prev[workspaceId],
    [serviceName]: {
      ...prev[workspaceId]?.[serviceName],
      [version]: !prev[workspaceId]?.[serviceName]?.[version],
    },
  },
}));
```

- **Saving Changes via PATCH Requests**
```tsx
await apiCall(
  `${ApiEndpoint.Workspaces}/${update.workspaceId}`,
  HttpMethod.Patch,
  update.payload
);
```

- **Handles Errors & Displays Failed Workspaces**
```tsx
if (failedWorkspaces.length > 0) {
  setUpdateErrors(failedWorkspaces);
}
```

- **Removes Debugging Output**
The <pre> tag displaying the updatedWorkspaces object can bee removed, as it was only used for debugging


![image](https://github.com/user-attachments/assets/7af837b5-4e42-4c42-8c9c-d3ece31986bc)

---

### **GenericTable.tsx**
This component provides a **reusable table** that can display dynamic data with configurable columns.  

- Created a **reusable table component** to display **workspaces and service versions**.
- Accepts `data` and `columns` as props.
- **Each cell uses a render function**, allowing different content per column.

#### **Example Usage:**
```tsx
interface ExampleData {
  id: string;
  name: string;
  version: string;
}

const exampleData: ExampleData[] = [
  { id: "1", name: "Service A", version: "v1.0" },
  { id: "2", name: "Service B", version: "v2.1" },
];

const columns = [
  { key: "name", name: "Service Name", render: (item: ExampleData) => <span>{item.name}</span> },
  { key: "version", name: "Version", render: (item: ExampleData) => <span>{item.version}</span> },
];

export const ExampleComponent = () => {
  return <GenericTable data={exampleData} columns={columns} />;
};
```

---

### **CreateUpdateResource.tsx**
This component is responsible for controlling what is displayed in the sidebar. Depending on the provided props, it renders different pages.

- Introduced `templateVersion` state to store the selected service version.
- Passed `templateVersion` to `SelectTemplate.tsx` and `ResourceForm.tsx` to track versions across components.
- **Commented out setting the version in `ResourceForm.tsx`** to avoid issues while mock data is still used, you can uncomment once API work is complete

---

### **SelectTemplate.tsx**
This component is responsible for displaying available templates when selecting a resource type (e.g., workspaces, workspace services, etc.). 

- Added a dropdown for version selection but only for workspace services. 
- If `template.versions` exist, they are used; otherwise, mock versions (1-3 items) are generated. 
- Defaults to the latest version in the list. 
- Disables the dropdown if only one version exists. 
- When "Create" is clicked, the selected version is sent to `CreateUpdateResource.tsx`, allowing it to be used in the resource template on the next page. 
- Remove any use case of generating mock versions once the API (`workspace-service-templates/{workspace_service_name}`) is updated to return versions as a string array per template. 


![image](https://github.com/user-attachments/assets/bbfe4227-437e-45bf-b28b-fcf053fd0f74)

---

### **ResourceForm.tsx**  
This component is responsible for editing and updating resources across all resource types, including workspaces and workspace services.  

- **Modified API call** to include `version` as a query parameter when fetching workspace service templates.  
- Ensures the selected version is correctly fetched when updating workspace services, while other resource types remain unchanged. 

![image](https://github.com/user-attachments/assets/89bf0b3e-1932-4d8c-b0c2-0d0b8d7e720e)

---


