### PR TITLE
Replace our trick to fetch both storage keys

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/windowsvm.tf
@@ -44,7 +44,8 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
       nexus_proxy_url        = local.nexus_proxy_url
       SharedStorageAccess    = var.shared_storage_access ? 1 : 0
       StorageAccountName     = data.azurerm_storage_account.stg.name
-      StorageAccountKey      = data.azurerm_storage_account.stg.primary_access_key
+      StorageAccountKey1     = data.azurerm_storage_account.stg.primary_access_key
+      StorageAccountKey2     = data.azurerm_storage_account.stg.secondary_access_key
       StorageAccountFileHost = data.azurerm_storage_account.stg.primary_file_host
       FileShareName          = var.shared_storage_access ? var.shared_storage_name : ""
       CondaConfig            = local.selected_image.conda_config ? 1 : 0


### PR DESCRIPTION
We use both storage account keys for the shared storage, in case one starts with a `/`, which is then misinterpreted as an option by the `net use` command that mounts the drive.

This was a fix that Andrii put in a while back, after we hit that problem. I'd lost it in the merge, so am replacing it again.