### PR TITLE
Patch linux vm/pre merge v0.21.0

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.8
+version: 1.2.9
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -16,8 +16,8 @@ custom:
     "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
     "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
     "6 CPU | 55GB RAM | 1/6 x A10 GPU": Standard_NV6ads_A10_v5 #  533
-    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV6ads_A10_v5 # 1066
-    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV6ads_A10_v5 # 1772
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV12ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV18ads_A10_v5 # 1772
     "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5 # 2375
     "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323
   image_options:


### PR DESCRIPTION
# Resolves #266

Menus updated, version bumped to 1.2.9.

Tested in Ubuntu 22.04 and 24.04 with 12 CPUs.