### PR TITLE
Patch windows vm/pre merge v0.21.0

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.10
+version: 1.2.11
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -16,12 +16,12 @@ custom:
     "32 CPU | 128GB RAM": Standard_D32s_v5 # 1096
     "64 CPU | 256GB RAM": Standard_D64s_v5 # 2134
     "6 CPU | 55GB RAM | 1/6 x A10 GPU": Standard_NV6ads_A10_v5 #  533
-    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV6ads_A10_v5 # 1066
-    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV6ads_A10_v5 # 1772
+    "12 CPU | 110GB RAM | 1/3 x A10 GPU": Standard_NV12ads_A10_v5 # 1066
+    "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV18ads_A10_v5 # 1772
     "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5 # 2375
     "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323
   image_options:
-    "Windows 10":
+    "(deprecated) Windows 10":
       source_image_reference:
         publisher: MicrosoftWindowsDesktop
         offer: Windows-10
@@ -30,7 +30,7 @@ custom:
       conda_config: false
       secure_boot_enabled: true
       vtpm_enabled: true
-    "Windows 11":
+    "(deprecated) Windows 11":
       source_image_reference:
         publisher: microsoftwindowsdesktop
         offer: windows-11
@@ -39,7 +39,7 @@ custom:
       conda_config: false
       secure_boot_enabled: true
       vtpm_enabled: true
-    "Server 2019 Data Science VM":
+    "(deprecated) Server 2019 Data Science VM":
       source_image_reference:
         publisher: microsoft-dsvm
         offer: dsvm-win-2019
@@ -49,11 +49,20 @@ custom:
       secure_boot_enabled: false # dsvm-win-2019 is not a gen2 image
       vtpm_enabled: false
     # For information on using custom images, see README.me in the guacamole/user-resources folder
-    "Custom Server 2019 Data Science VM":
+    "Custom Windows 11":
       source_image_name: imgdef-windows11-dsvm-rpython
       conda_config: true
     "Custom Windows 10":
       source_image_name: imgdef-windows10-dsvm-rpython
+      conda_config: true
+    "(2025-03) Custom Windows 10":
+      source_image_name: windows-10-2025-03
+      conda_config: true
+    "(2025-03) Custom Windows 11":
+      source_image_name: windows-11-2025-03
+      conda_config: true
+    "(2025-03) Custom Windows 2019 Data Science VM":
+      source_image_name: windows-19-DS-2025-03
       conda_config: true
 
 credentials:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -30,11 +30,14 @@
       "title": "Windows image",
       "description": "Select Windows image to use for VM",
       "enum": [
-        "Custom Server 2019 Data Science VM",
+        "(2025-03) Custom Windows 2019 Data Science VM",
+        "(2025-03) Custom Windows 11",
+        "(2025-03) Custom Windows 10",
+        "Custom Windows 11",
         "Custom Windows 10",
-        "Server 2019 Data Science VM",
-        "Windows 10",
-        "Windows 11"
+        "(deprecated) Server 2019 Data Science VM",
+        "(deprecated) Windows 10",
+        "(deprecated) Windows 11"
       ]
     },
     "vm_size": {

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/vm_config.ps1
@@ -60,3 +60,11 @@ local({
 "@
 $RConfig | Out-File -Encoding Ascii ( New-Item -Path $Env:ProgramFiles\R\R-4.1.2\etc\Rprofile.site -Force )
 
+#
+# The new 2025-03 images have a conda config that doesn't get cleaned up. Do that here.
+# Turn off error handling since I don't know how this will work in older images. For
+# the same reason, put it at the end of the script.
+$ErrorActionPreference = "Continue"
+conda config --remove channels https://repo.anaconda.com/pkgs/main --system
+conda config --remove channels https://repo.anaconda.com/pkgs/r --system
+conda config --remove channels https://repo.anaconda.com/pkgs/msys2 --system


### PR DESCRIPTION
Conda wasn't working in the new images because the old conda configuration wasn't flushed out. This PR adds code to the startup script to clean the config, and also renames/re-orders the images to show their value.