### PR TITLE
Implement fix from #4557 of upstream, change in 'az login' behaviour

### DIFF
--- a/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
+++ b/core/terraform/resource_processor/vmss_porter/cloud-config.yaml
@@ -87,7 +87,7 @@ runcmd:
   - printf '\nalias rpstatus='\''tmux new-session -d "watch docker ps"; tmux split-window -p 100 -v "docker logs --since 1m --follow resource_processor1"; tmux split-window -v -p 90; tmux -2 attach-session -d'\''\n' >> /etc/bash.bashrc
   - export DEBIAN_FRONTEND=noninteractive
   - az cloud set --name ${azure_environment}
-  - az login --identity -u ${vmss_msi_id}
+  - az login --identity --client-id ${vmss_msi_id}
   - az acr login --name ${docker_registry_server}
   - docker run -d -p 8080:8080 -v /var/run/docker.sock:/var/run/docker.sock
     --restart always --env-file .env


### PR DESCRIPTION
The Resource Processor is failing due to a change in the behaviour of `az login`. This has been fixed in the upstream repo, this change brings the same one-line fix here.