### PR TITLE
Increase airlock review VM disk size to 512GB

### DIFF
--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/download_review_data.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/download_review_data.ps1
@@ -1,3 +1,10 @@
+# Extend the C:\ drive to the end of the disk
+Write-Output "*** Extending C:\ drive to fill the disk"
+$size = Get-PartitionSupportedSize -DriveLetter C
+Resize-Partition -DriveLetter C -Size $size.SizeMax
+
+# Download the review data
+Write-Output "*** Downloading review data"
 $DownloadPath = $env:Public + "\Desktop\ReviewData"
 mkdir $DownloadPath
 az storage blob download-batch -d $DownloadPath -s '"${airlock_request_sas_url}"'

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-export-reviewvm/terraform/windowsvm.tf
@@ -146,6 +146,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
     name                   = "osdisk-${local.vm_name}"
     caching                = "ReadWrite"
     storage_account_type   = "Standard_LRS"
+    disk_size_gb           = 512
     disk_encryption_set_id = var.enable_cmk_encryption ? azurerm_disk_encryption_set.windowsvm_disk_encryption[0].id : null
   }
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/download_review_data.ps1
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/download_review_data.ps1
@@ -1,3 +1,10 @@
+# Extend the C:\ drive to the end of the disk
+Write-Output "*** Extending C:\ drive to fill the disk"
+$size = Get-PartitionSupportedSize -DriveLetter C
+Resize-Partition -DriveLetter C -Size $size.SizeMax
+
+# Download the review data
+Write-Output "*** Downloading review data"
 $DownloadPath = $env:Public + "\Desktop\ReviewData"
 mkdir $DownloadPath
 az storage blob download-batch -d $DownloadPath -s '"${airlock_request_sas_url}"'

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-import-reviewvm/terraform/windowsvm.tf
@@ -67,6 +67,7 @@ resource "azurerm_windows_virtual_machine" "windowsvm" {
     name                   = "osdisk-${local.vm_name}"
     caching                = "ReadWrite"
     storage_account_type   = "Standard_LRS"
+    disk_size_gb           = 512
     disk_encryption_set_id = var.enable_cmk_encryption ? azurerm_disk_encryption_set.windowsvm_disk_encryption[0].id : null
   }
 


### PR DESCRIPTION
Increases the OS disk size on import and export review VMs to 512GB and adds a PowerShell script step to extend the C:\ partition to use the full disk space before downloading review data.
