### PR TITLE
feat(linuxvm): add A100 and H100 GPU VM sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **BREAKING CHANGES**
 
 ENHANCEMENTS:
+* Add A100 (Standard_NC24ads_A100_v4) and H100 (Standard_NC40ads_H100_v5) GPU VM sizes to Linux VM user resource template ([guacamole-azure-linuxvm v1.3.0](templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **BREAKING CHANGES**
 
 ENHANCEMENTS:
-* Add A100 (Standard_NC24ads_A100_v4) and H100 (Standard_NC40ads_H100_v5) GPU VM sizes to Linux VM user resource template ([guacamole-azure-linuxvm v1.3.0](templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm))
+* Add A100 (Standard_NC24ads_A100_v4) and H100 (Standard_NC40ads_H100_v5) GPU VM sizes to Linux and Windows VM user resource templates ([guacamole-azure-linuxvm v1.2.10](templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm), [guacamole-azure-windowsvm v1.2.12](templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm))
 
 BUG FIXES:
 

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.9
+version: 1.3.0
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -20,6 +20,8 @@ custom:
     "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV18ads_A10_v5 # 1772
     "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5 # 2375
     "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323
+    "24 CPU | 220GB RAM | 1 x A100 80GB GPU": Standard_NC24ads_A100_v4 # 3306
+    "40 CPU | 320GB RAM | 1 x H100 80GB GPU": Standard_NC40ads_H100_v5 # 5065
   image_options:
     # "Ubuntu 22.04 LTS":
     #   source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.3.0
+version: 1.2.10
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/template_schema.json
@@ -55,7 +55,9 @@
         "12 CPU | 110GB RAM | 1/3 x A10 GPU",
         "18 CPU | 220GB RAM | 1/2 x A10 GPU",
         "36 CPU | 440GB | 1 x A10 GPU",
-        "36 CPU | 880GB | 1 x A10 GPU"
+        "36 CPU | 880GB | 1 x A10 GPU",
+        "24 CPU | 220GB RAM | 1 x A100 80GB GPU",
+        "40 CPU | 320GB RAM | 1 x H100 80GB GPU"
       ],
       "updateable": true
     },

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.11
+version: 1.2.12
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -20,6 +20,8 @@ custom:
     "18 CPU | 220GB RAM | 1/2 x A10 GPU": Standard_NV18ads_A10_v5 # 1772
     "36 CPU | 440GB | 1 x A10 GPU": Standard_NV36ads_A10_v5 # 2375
     "36 CPU | 880GB | 1 x A10 GPU": Standard_NV36adms_A10_v5 # 3323
+    "24 CPU | 220GB RAM | 1 x A100 80GB GPU": Standard_NC24ads_A100_v4 # 3306
+    "40 CPU | 320GB RAM | 1 x H100 80GB GPU": Standard_NC40ads_H100_v5 # 5065
   image_options:
     "(deprecated) Windows 10":
       source_image_reference:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/template_schema.json
@@ -56,7 +56,9 @@
         "12 CPU | 110GB RAM | 1/3 x A10 GPU",
         "18 CPU | 220GB RAM | 1/2 x A10 GPU",
         "36 CPU | 440GB | 1 x A10 GPU",
-        "36 CPU | 880GB | 1 x A10 GPU"
+        "36 CPU | 880GB | 1 x A10 GPU",
+        "24 CPU | 220GB RAM | 1 x A100 80GB GPU",
+        "40 CPU | 320GB RAM | 1 x H100 80GB GPU"
       ],
       "updateable": true
     },


### PR DESCRIPTION
## Summary

- Adds `Standard_NC24ads_A100_v4` (24 CPU | 220GB RAM | 1 x A100 80GB GPU) to the Linux VM user resource template
- Adds `Standard_NC40ads_H100_v5` (40 CPU | 320GB RAM | 1 x H100 80GB GPU) to the Linux VM user resource template
- Bumps `guacamole-azure-linuxvm` bundle version `1.2.9` → `1.3.0`

Both SKUs are now available as selectable options in the TRE portal when creating a Linux VM user resource.

## Motivation

Required to deploy PharosAI PoC2 FL SuperNode VMs (GPU-accelerated federated learning clients) through the TRE pipeline, making them visible and lifecycle-managed via the TRE portal rather than requiring direct Azure CLI deployment.

## Changes

- `porter.yaml` — added two entries to `vm_sizes` map, version bumped to 1.3.0
- `template_schema.json` — added two entries to `vm_size` enum
- `CHANGELOG.md` — recorded under 0.27.0 ENHANCEMENTS

## Test plan

- [ ] Bundle builds cleanly: `make bundle-build DIR=templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm`
- [ ] New VM size options appear in TRE portal when creating a Linux VM in a workspace
- [ ] Deploy a test VM using `24 CPU | 220GB RAM | 1 x A100 80GB GPU` in workspace rg-sdebeta-ws-63c2
- [ ] Verify GPU is accessible inside the VM (`nvidia-smi`)