### PR TITLE
fix(airlock-notifier): notify only request submitter on approval, remove in_review notification

### DIFF
--- a/templates/shared_services/airlock_notifier/app/AirlockNotifier/workflow.json
+++ b/templates/shared_services/airlock_notifier/app/AirlockNotifier/workflow.json
@@ -191,47 +191,22 @@
                   "value": "Your Airlock request was approved"
                 },
                 "runAfter": {
-                  "Set_recipients_as_researchers_emails": [
+                  "Set_recipient_as_submitter_email": [
                     "Succeeded"
                   ]
                 },
                 "type": "SetVariable"
               },
-              "Set_recipients_as_researchers_emails": {
+              "Set_recipient_as_submitter_email": {
                 "inputs": {
                   "name": "recipients",
-                  "value": "@body('Parse_JSON')?['data']?['recipient_emails_by_role']?['workspace_researcher']"
+                  "value": "@array(body('Parse_JSON')?['data']?['request']?['createdBy']?['email'])"
                 },
                 "runAfter": {},
                 "type": "SetVariable"
               }
             },
             "case": "approved"
-          },
-          "Case_in_review": {
-            "actions": {
-              "Set_in_review_message": {
-                "inputs": {
-                  "name": "message",
-                  "value": "An Airlock request needs your review"
-                },
-                "runAfter": {
-                  "Set_recipients_as_owners_emails": [
-                    "Succeeded"
-                  ]
-                },
-                "type": "SetVariable"
-              },
-              "Set_recipients_as_owners_emails": {
-                "inputs": {
-                  "name": "recipients",
-                  "value": "@body('Parse_JSON')?['data']?['recipient_emails_by_role']?['airlock_manager']"
-                },
-                "runAfter": {},
-                "type": "SetVariable"
-              }
-            },
-            "case": "in_review"
           }
         },
         "default": {


### PR DESCRIPTION
## Summary

- Removes the `in_review` email notification to AirlockManagers — the SDE portal dashboard is sufficient for managers to track pending reviews, and the email was considered unnecessary noise
- Changes the `approved` notification recipient from the full `workspace_researcher` role list (all researchers in the workspace) to `request.createdBy.email` — only the person who submitted the request is notified when it is approved

## Notification matrix after this change

| Status | Recipient | Subject |
|--------|-----------|---------|
| `approved` | Request submitter (`createdBy.email`) | "Your Airlock request was approved" |
| All other statuses | Nobody | — |

## What changed

`templates/shared_services/airlock_notifier/app/AirlockNotifier/workflow.json`

- Removed `Case_in_review` switch case entirely
- Renamed `Set_recipients_as_researchers_emails` → `Set_recipient_as_submitter_email` and changed the value expression from `recipient_emails_by_role.workspace_researcher` (array) to `array(request.createdBy.email)` (single address wrapped in array for the join expression downstream)

## Related

Barts-Life-Science/cloud-ops#87 — root-cause ticket for airlock notifier not sending emails (Outlook connector unauthenticated). This PR addresses the notification logic; the connector authentication fix is tracked separately.