### PR TITLE
Enable DNS proxy on firewall policy by default

### DIFF
--- a/templates/shared_services/firewall/porter.yaml
+++ b/templates/shared_services/firewall/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-shared-service-firewall
-version: 1.3.2
+version: 1.3.3
 description: "An Azure TRE Firewall shared service"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/shared_services/firewall/terraform/firewall.tf
+++ b/templates/shared_services/firewall/terraform/firewall.tf
@@ -84,5 +84,10 @@ resource "azurerm_firewall_policy" "root" {
   sku                 = local.effective_firewall_sku
   tags                = local.tre_shared_service_tags
 
+  dns {
+    proxy_enabled = var.firewall_dns_proxy_enabled
+    servers       = var.firewall_dns_servers
+  }
+
   lifecycle { ignore_changes = [tags] }
 }

--- a/templates/shared_services/firewall/terraform/variables.tf
+++ b/templates/shared_services/firewall/terraform/variables.tf
@@ -32,3 +32,15 @@ variable "firewall_force_tunnel_ip" {
   type    = string
   default = ""
 }
+
+variable "firewall_dns_proxy_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable DNS proxy on the firewall policy. Required for spoke VNets that point at the firewall IP for DNS to reach Azure DNS and linked private DNS zones."
+}
+
+variable "firewall_dns_servers" {
+  type        = list(string)
+  default     = []
+  description = "Upstream DNS servers used by the firewall when proxy is enabled. Empty list = Azure-provided DNS."
+}


### PR DESCRIPTION
## Summary
- Add `dns` block on `azurerm_firewall_policy.root` driven by two new variables (`firewall_dns_proxy_enabled` default `true`, `firewall_dns_servers` default `[]` = Azure DNS).
- Bump `tre-shared-service-firewall` porter version `1.3.2 → 1.3.3`.

## Why
On Barts-Life-Science SDE-beta workspaces, spoke VNets have no custom DNS — workspace VMs use the firewall IP as resolver. With `proxy_enabled = false` (the provider default, and what the IaC has shipped), those VMs cannot resolve anything, including PE-backed storage endpoints. Observed 2026-05-19 on `linuxvm6f4c` in `rg-sdebeta-ws-b8d7`: DNS timeouts on `10.1.0.4#53`, `blobfuse2-datalake-poc2.service` stuck `activating`, `/datalake-poc2` empty. Live setting had been kept on out-of-band; a redeploy or drift flipped it off across every SDE-beta workspace at once.

Runtime fix already applied via CLI on 2026-05-19 (`enableProxy: true` on `fw-policy-sdebeta`, mount restored). This PR locks the setting into IaC so the fix doesn't drift back.

## Test plan
- [x] `terraform fmt -check` clean on changed files
- [x] Runtime equivalent (`enableProxy: true`, `servers: [168.63.129.16]`) verified on live `fw-policy-sdebeta`: `linuxvm6f4c` resolves `stgwsb8d7.blob.core.windows.net → 10.1.40.6`, blobfuse mount `active (running)`, `/datalake-poc2` populated
- [ ] Next shared-service deploy: `az network firewall policy show -n fw-policy-sdebeta -g rg-sdebeta --query dnsSettings` returns `enableProxy: true` and no `terraform plan` drift on subsequent applies

## Self-merge carve-out
Per `feedback_self_merge_simple_changes` memory: 3 files, +18/-1, mechanical addition with safe defaults; live runtime already validated; defaults match the previously-correct production state.

Resolves #330