### PR TITLE
Add fork-aware Trivy licence scan workflow

### DIFF
--- a/.github/scripts/trivy_license_scan.sh
+++ b/.github/scripts/trivy_license_scan.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Direct-dependency licence + vulnerability scan for Barts-touched manifests.
+# Called by .github/workflows/trivy_license_scan.yml (PharosAI-BH #87).
+#
+# Why this is not a one-line `trivy fs`:
+#   Trivy reads pip/npm LICENCE metadata from INSTALLED packages, not from a
+#   bare requirements.txt / package.json. A bare-manifest licence scan returns
+#   zero licences (verified) -- a gate on that never fires. So we install, then
+#   scan with --license-full.
+#   #8 says track DIRECT dependencies, not nested ones. So we install direct
+#   deps only (`pip --no-deps`; npm direct-dep name filter) and gate on those.
+#
+# Per manifest, writes to $OUTDIR:
+#   sbom/<slug>.cdx.json   CycloneDX SBOM (vuln + license scanners)
+#   vuln/<slug>.json       MEDIUM+ vulnerabilities (non-blocking, triaged per #87)
+#   license/<slug>.json    direct-dep licences (--license-full)
+# Exit 1 if any direct dependency carries a restricted/forbidden (copyleft) licence.
+
+set -euo pipefail
+
+MANIFEST_LIST="${1:?usage: trivy_license_scan.sh <manifest-list-file>}"
+OUTDIR="${OUTDIR:-reports}"
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+mkdir -p "${OUTDIR}/sbom" "${OUTDIR}/vuln" "${OUTDIR}/license"
+gate_failed=0
+npm_done=" "  # directories already licence-scanned via npm, to avoid double work
+
+slug() { echo "$1" | tr '/' '_'; }
+
+# A package's own licence lives in LICENSE/COPYING; third-party NOTICE files list
+# the licences of projects the package merely references (e.g. TypeScript's
+# ThirdPartyNoticeText.txt carries CC-BY-NC entries while TypeScript itself is
+# Apache-2.0). --license-full reads loose files indiscriminately, so skip notice
+# files to avoid misattributing a referenced licence to the package.
+NOTICE_SKIP='**/ThirdPartyNotice*,**/*ThirdPartyNotice*,**/NOTICE*,**/*-NOTICE*,**/THIRD-PARTY*,**/third-party*,**/ThirdParty*'
+
+# Scan an installed direct-dep tree for restricted/forbidden licences.
+# $1 = manifest path (label), $2 = directory of installed packages.
+scan_installed_licences() {
+  local manifest="$1" dir="$2" slugged
+  slugged=$(slug "${manifest}")
+  trivy fs --quiet --scanners license --license-full --skip-files "${NOTICE_SKIP}" \
+    --format json --output "${OUTDIR}/license/${slugged}.json" "${dir}"
+  # Gate: HIGH/CRITICAL licence classification == restricted/forbidden (copyleft).
+  if ! trivy fs --quiet --scanners license --license-full --skip-files "${NOTICE_SKIP}" \
+    --severity HIGH,CRITICAL --exit-code 1 "${dir}" >/dev/null 2>&1; then
+    echo "- Restricted/forbidden licence in direct deps of \`${manifest}\`" >> "${SUMMARY}"
+    gate_failed=1
+  else
+    echo "- Clean: \`${manifest}\`" >> "${SUMMARY}"
+  fi
+}
+
+# Vuln + SBOM run straight off the manifest (these DO resolve without install).
+scan_manifest_vuln_sbom() {
+  local manifest="$1" slugged
+  slugged=$(slug "${manifest}")
+  trivy fs --quiet --scanners license,vuln --format cyclonedx \
+    --output "${OUTDIR}/sbom/${slugged}.cdx.json" "${manifest}"
+  trivy fs --quiet --scanners vuln --severity MEDIUM,HIGH,CRITICAL \
+    --format json --output "${OUTDIR}/vuln/${slugged}.json" "${manifest}"
+}
+
+echo "## Trivy licence scan (fork-aware, direct deps only)" >> "${SUMMARY}"
+echo "" >> "${SUMMARY}"
+
+while IFS= read -r manifest; do
+  [ -z "${manifest}" ] && continue
+  [ -f "${manifest}" ] || { echo "- Skipped (not found): \`${manifest}\`" >> "${SUMMARY}"; continue; }
+  base=$(basename "${manifest}")
+  # Maven needs network POM fetches from Maven Central; CI runners hit 429 rate
+  # limiting (same as #87). Skip ALL Trivy calls (even vuln/SBOM trigger fetches)
+  # and defer to #89 (Nexus proxy in the TRE). Must short-circuit before any
+  # trivy call, else the 429 aborts the run under `set -e`.
+  if [ "${base}" = "pom.xml" ]; then
+    echo "- Licence scan deferred (Maven needs network POMs; tracked in #89): \`${manifest}\`" >> "${SUMMARY}"
+    continue
+  fi
+  scan_manifest_vuln_sbom "${manifest}"
+  workdir=$(mktemp -d)
+  case "${base}" in
+    requirements*.txt)
+      # Direct deps only: --no-deps installs just the pinned packages.
+      if pip install --quiet --no-deps --target "${workdir}" -r "${manifest}" 2>/dev/null; then
+        scan_installed_licences "${manifest}" "${workdir}"
+      else
+        echo "- Licence scan incomplete (pip install failed): \`${manifest}\`" >> "${SUMMARY}"
+        gate_failed=1
+      fi
+      ;;
+    package.json | yarn.lock)
+      # npm hoists the FULL transitive tree into a flat node_modules, so scanning
+      # node_modules wholesale would flag transitive copyleft -- #8 says direct
+      # deps only. So: install to resolve, then stage only the directories named
+      # in package.json (dependencies + devDependencies) and scan those.
+      mdir=$(dirname "${manifest}")
+      if [ ! -f "${mdir}/package.json" ]; then
+        # yarn.lock with no package.json alongside (e.g. a bare lockfile dir).
+        echo "- Licence scan skipped (no package.json beside lockfile): \`${manifest}\`" >> "${SUMMARY}"
+        rm -rf "${workdir}"; continue
+      fi
+      # package.json + yarn.lock in one dir resolve to the same deps; scan once.
+      if [ "${npm_done#* "${mdir}" }" != "${npm_done}" ]; then
+        rm -rf "${workdir}"; continue
+      fi
+      npm_done="${npm_done}${mdir} "
+      (cd "${mdir}" && npm install --silent --no-audit --no-fund --ignore-scripts \
+        --package-lock=false >/dev/null 2>&1) || true
+      # Direct-dep names from the manifest.
+      mapfile -t direct < <(python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for k in ("dependencies", "devDependencies"):
+    for name in d.get(k, {}):
+        print(name)
+' "${mdir}/package.json")
+      staged=0
+      for name in "${direct[@]}"; do
+        if [ -d "${mdir}/node_modules/${name}" ]; then
+          mkdir -p "${workdir}/$(dirname "${name}")"
+          cp -r "${mdir}/node_modules/${name}" "${workdir}/${name}"
+          staged=$((staged + 1))
+        fi
+      done
+      rm -rf "${mdir}/node_modules"
+      if [ "${staged}" -eq 0 ]; then
+        echo "- Licence scan skipped (no direct deps resolved): \`${manifest}\`" >> "${SUMMARY}"
+      else
+        scan_installed_licences "${manifest}" "${workdir}"
+      fi
+      ;;
+    *)
+      echo "- Licence scan skipped (unsupported manifest type): \`${manifest}\`" >> "${SUMMARY}"
+      ;;
+  esac
+  rm -rf "${workdir}"
+done < "${MANIFEST_LIST}"
+
+if [ "${gate_failed}" -ne 0 ]; then
+  echo "::error::Restricted or forbidden licence found in a Barts-touched direct dependency."
+  exit 1
+fi
+echo "All Barts-touched direct dependencies carry permissive licences."

--- a/.github/workflows/trivy_license_scan.yml
+++ b/.github/workflows/trivy_license_scan.yml
@@ -1,0 +1,103 @@
+---
+# Fork-aware dependency licence and vulnerability scan (PharosAI-BH #87).
+#
+# Barts-Life-Science/AzureTRE is a fork of microsoft/AzureTRE. For commercial-use
+# licence assurance we only own the dependencies WE changed, not Microsoft's
+# upstream tree. This workflow scans only the dependency manifests that diverge
+# from upstream/main, so pure-upstream manifests produce no noise.
+#
+# Licence resolution and direct-vs-transitive scoping live in
+# .github/scripts/trivy_license_scan.sh (see header there for the why).
+
+name: "Trivy licence scan"
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, development]
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  TRIVY_VERSION: "0.71.0"
+
+jobs:
+  scan:
+    name: Scan Barts-touched manifests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout fork (full history)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/microsoft/AzureTRE.git
+          git fetch --quiet upstream main
+
+      - name: Compute Barts-touched dependency manifests
+        id: manifests
+        run: |
+          set -euo pipefail
+          # Manifest filenames Trivy understands; anchored to path end.
+          pattern='(^|/)(requirements[^/]*\.txt|package\.json|package-lock\.json|yarn\.lock|pyproject\.toml|poetry\.lock|Pipfile|Pipfile\.lock|go\.mod|go\.sum|pom\.xml|build\.gradle|build\.gradle\.kts|Gemfile|Gemfile\.lock|composer\.json|composer\.lock|Cargo\.toml|Cargo\.lock|[^/]*\.csproj|packages\.config)$'
+          base=$(git merge-base upstream/main HEAD)
+          # Manifests added or modified on the Barts side vs the merge-base.
+          git diff --name-only --diff-filter=AM "${base}" HEAD \
+            | grep -vE '(^|/)(node_modules|vendor|\.venv|site-packages)/' \
+            | grep -iE "${pattern}" | sort -u > barts_manifests.txt || true
+          count=$(wc -l < barts_manifests.txt)
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+          if [ "${count}" -eq 0 ]; then
+            echo "No Barts-touched dependency manifests in this diff."
+          else
+            echo "Barts-touched manifests:"
+            sed 's/^/  /' barts_manifests.txt
+          fi
+
+      - name: Set up Python
+        if: steps.manifests.outputs.count != '0'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node.js
+        if: steps.manifests.outputs.count != '0'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Trivy (pinned)
+        if: steps.manifests.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/aquasecurity/trivy/v${TRIVY_VERSION}/contrib/install.sh" \
+            | sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
+          trivy --version
+
+      - name: Scan (SBOM + direct-dep licence gate + vuln report)
+        if: steps.manifests.outputs.count != '0'
+        env:
+          OUTDIR: reports
+        run: |
+          chmod +x .github/scripts/trivy_license_scan.sh
+          .github/scripts/trivy_license_scan.sh barts_manifests.txt
+
+      - name: Upload SBOM and scan reports
+        if: steps.manifests.outputs.count != '0' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-licence-scan-reports
+          path: reports/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Net-new CI workflow scanning AzureTRE dependency manifests for licence and vulnerability risk, scoped to the Barts side of the microsoft/AzureTRE fork (#87).
- Gates PRs on restricted/forbidden (copyleft) licences in Barts-touched direct dependencies; emits CycloneDX SBOMs and vulnerability reports as artifacts.

## Changes
- `.github/workflows/trivy_license_scan.yml` -> on PR/push/weekly, diffs against `upstream/main`, computes Barts-touched manifests, installs pinned Trivy v0.71.0, runs the scan, uploads reports.
- `.github/scripts/trivy_license_scan.sh` -> per-manifest scan: pip (`--no-deps`) and npm (direct-dep filter) resolve direct-only licences per #8 boundary; vuln + SBOM run off the manifest; Maven deferred to the Nexus-proxy shared service.

## Note
Maven (`pom.xml`) licence resolution needs network POM fetches that hit Maven Central rate limits on CI runners; deferred to the TRE Nexus-proxy shared service tracked in #89, not silently dropped.

## Related Issues
Resolves #87