### PR TITLE
feat(workspace,vm): fold archive blob storage into base workspace

### DIFF
--- a/deploy-archive-refactor.sh
+++ b/deploy-archive-refactor.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# deploy-archive-refactor.sh
+#
+# End-to-end runner for the "fold blob-storage into base workspace" refactor.
+#   • Publishes the three updated bundles to ACR (auto)
+#   • Verifies the new versions appear in the registry (auto)
+#   • Pauses for the four TRE UI clicks (manual; instructions printed)
+#   • Prints the smoke-test commands to paste on the workspace VM (manual)
+#
+# Run from the repo root:
+#     ./deploy-archive-refactor.sh
+# ---------------------------------------------------------------------------
+set -o errexit
+set -o pipefail
+set -o nounset
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+BASE_VER=2.1.0
+LINUX_VER=1.2.15
+WIN_VER=1.2.14
+
+# Discoverable from core/private.env or fall back to known value for this TRE
+TRE_ID="${TRE_ID:-devtre02}"
+WS_SUFFIX="${WS_SUFFIX:-270e}"
+
+banner() { printf "\n\033[1;36m=== %s ===\033[0m\n" "$*"; }
+
+# ---------------------------------------------------------------------------
+banner "Phase 1 — publish updated bundles to ACR"
+# ---------------------------------------------------------------------------
+echo "Publishing base workspace ${BASE_VER}, linuxvm ${LINUX_VER}, windowsvm ${WIN_VER}..."
+
+make workspace_bundle BUNDLE=base
+make user_resource_bundle WORKSPACE_SERVICE=guacamole BUNDLE=guacamole-azure-linuxvm
+make user_resource_bundle WORKSPACE_SERVICE=guacamole BUNDLE=guacamole-azure-windowsvm
+
+# ---------------------------------------------------------------------------
+banner "Phase 1 verification — confirm new tags are in ACR"
+# ---------------------------------------------------------------------------
+# Resolve ACR_NAME in this order: env var, core/private.env, config.yaml.
+if [[ -z "${ACR_NAME:-}" && -f core/private.env ]]; then
+  # shellcheck disable=SC1091
+  set +o nounset; source core/private.env; set -o nounset
+fi
+if [[ -z "${ACR_NAME:-}" && -f config.yaml ]] && command -v yq >/dev/null 2>&1; then
+  ACR_NAME="$(yq '.management.acr_name // .acr_name' config.yaml | tr -d '"' | sed '/^null$/d')"
+fi
+: "${ACR_NAME:?ACR_NAME not resolved from env, core/private.env, or config.yaml}"
+
+echo "Latest tags in ACR ($ACR_NAME):"
+for repo in \
+    tre-workspace-base \
+    tre-service-guacamole-linuxvm \
+    tre-service-guacamole-windowsvm; do
+  printf "  %-40s -> " "$repo"
+  az acr repository show-tags --name "$ACR_NAME" --repository "$repo" \
+     --orderby time_desc --top 1 -o tsv | head -1
+done
+
+cat <<EOF
+
+Expected most-recent tags:
+  tre-workspace-base                       -> v${BASE_VER}
+  tre-service-guacamole-linuxvm            -> v${LINUX_VER}
+  tre-service-guacamole-windowsvm          -> v${WIN_VER}
+EOF
+
+# ---------------------------------------------------------------------------
+banner "Next steps — TRE UI + smoke test (manual, no more script needed)"
+# ---------------------------------------------------------------------------
+cat <<EOF
+
+Bundles are now published to ACR. Finish the rollout with these steps in the
+TRE UI for workspace ${WS_SUFFIX}, then smoke-test on the VM.
+
+------------------------------------------------------------
+Step A — decommission the old standalone Blob Storage service
+------------------------------------------------------------
+  Workspace Services -> Blob Storage -> ⋮ -> Disable -> (wait ~1-2 min) ->
+  ⋮ -> Delete -> confirm.
+
+  This tears down stgblobsvc<random>, its private endpoint, and the role
+  assignment we put on it earlier today. The 'demo.txt' blob goes with it.
+
+------------------------------------------------------------
+Step B — upgrade the workspace 2.0.3 -> ${BASE_VER}
+------------------------------------------------------------
+  Workspace -> Properties (or Workspace -> ⋮) -> Upgrade -> pick ${BASE_VER}
+  -> Submit. Wait ~3-5 min.
+
+  Adds the 'archive' container + lifecycle policy to the existing workspace
+  shared storage account. Existing VMs and the shared file share keep
+  running through the upgrade.
+
+------------------------------------------------------------
+Step C — upgrade existing VMs (one per VM)
+------------------------------------------------------------
+  Linux VM (linuxvmd4e0):
+    Guacamole -> linuxvmd4e0 -> ⋮ -> Upgrade -> pick ${LINUX_VER}.
+
+  Windows VM (if you have one):
+    Guacamole -> <windows-vm-name> -> ⋮ -> Upgrade -> pick ${WIN_VER}.
+
+  Each upgrade adds the role assignment that grants the VM's managed
+  identity 'Storage Blob Data Contributor' on the workspace shared SA.
+  VMs are NOT recreated; no reboot.
+
+------------------------------------------------------------
+Step D — smoke test (on the workspace VM, not here)
+------------------------------------------------------------
+Open Guacamole -> connect to linuxvmd4e0 -> terminal, then paste:
+
+  SA=stg<your-workspace-suffix>     # from workspace Outputs in the TRE UI
+  CONT=archive
+
+  az login --identity
+  az account show --query "user.name" -o tsv      # expect: systemAssignedIdentity
+
+  nslookup \$SA.blob.core.windows.net | grep -E "privatelink|Address"
+
+  echo "hello \$(date)" > /tmp/x
+  az storage blob upload   --account-name \$SA --container-name \$CONT --auth-mode login --name x --file /tmp/x
+  az storage blob list     --account-name \$SA --container-name \$CONT --auth-mode login -o table
+  az storage blob download --account-name \$SA --container-name \$CONT --auth-mode login --name x --file /tmp/x-out
+  diff /tmp/x /tmp/x-out && echo "round-trip OK"
+
+When you see 'round-trip OK', the refactor is fully verified.
+EOF
+
+banner "Bundle publishes complete. ✅  Now do steps A-D above."

--- a/docs/using-tre/tre-for-research/working-with-blob-storage.md
+++ b/docs/using-tre/tre-for-research/working-with-blob-storage.md
@@ -1,0 +1,256 @@
+# Working with Blob Storage from your workspace VM
+
+Every workspace has an **`archive` blob container** on its shared storage account — meant for **cold / archive data**, i.e. datasets you want to keep but rarely access. Files you put in start on the Hot tier and the storage account automatically moves them to cheaper tiers (Cool → Cold → Archive) as time passes, so the longer data sits untouched, the less it costs.
+
+This page is for the **researcher already inside a workspace VM** who wants to push data into the `archive` container and pull it back out.
+
+## Prerequisites
+
+- A workspace deployed from the base workspace template (version 2.1.0 or later). The `archive` container and lifecycle policy come with it — there is **no separate workspace service to deploy**.
+- A workspace VM (Linux or Windows) deployed via Guacamole, with `Shared Storage Access` enabled (the default). You are connected to it through the Guacamole desktop.
+
+You do **not** need to know any storage account keys, set up a SAS token, or `az login` interactively. The VM authenticates as itself via its system-assigned managed identity, which is granted access to the storage automatically when the VM is provisioned.
+
+## Step 1 — Find your storage account name
+
+In the TRE UI:
+
+1. Open your workspace.
+2. Open the workspace **Outputs** tab (or **Properties** → **Outputs**, depending on UI version).
+3. Copy the value of `storage_account_name` (something like `stgworkspc270e`). This is the same storage account that hosts the workspace shared file-share.
+
+Set it as an environment variable on the VM so you don't have to retype it:
+
+```bash
+STG=stgworkspc270e          # paste the value from Outputs
+CONTAINER=archive           # always "archive" — this is the container with the lifecycle policy
+```
+
+## Step 2 — Confirm you're on the workspace network
+
+The storage account is unreachable from the public internet — it can only be talked to from inside your workspace vnet. A quick check:
+
+```bash
+nslookup $STG.blob.core.windows.net
+```
+
+You should see an answer like:
+
+```
+Name:    stgworkspc270e.privatelink.blob.core.windows.net
+Address: 10.1.4.27
+```
+
+Two things to look for:
+
+- The CNAME points to something with `privatelink` in the name.
+- The address starts with `10.` (a private IP inside your workspace).
+
+If you see a public address (e.g. `20.x.x.x`) or the lookup fails, you're not on the workspace network — open Guacamole and connect to the workspace VM.
+
+## Step 3 — Sign in as the VM
+
+The VM has its own identity (a **system-assigned managed identity**) that the storage account recognises. You log in *as the VM*, not as yourself — no passwords, no codes, no browser:
+
+```bash
+az login --identity
+az account show
+```
+
+The `az account show` output should include:
+
+```json
+"user": {
+    "name": "systemAssignedIdentity",
+    "type": "servicePrincipal"
+}
+```
+
+That's it — you can now use the storage.
+
+> Why not `az login` as yourself? In a TRE, your workspace VM is meant to be the actor that touches research data, not your laptop or your user account. Using the VM identity means everything you do is auditable as coming from *this specific VM*, and it sidesteps tenant sign-in policies that block interactive auth on workspace networks.
+
+## Step 4 — Upload a file
+
+```bash
+echo "hello from $(hostname) at $(date)" > demo.txt
+
+az storage blob upload \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --file ./demo.txt --name demo.txt
+```
+
+`--name` is what the file will be called inside the container. You can use a path-like name to organise into pseudo-folders:
+
+```bash
+az storage blob upload \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --file ./results.csv --name 2026-06/study1/results.csv
+```
+
+## Step 5 — List what's there
+
+```bash
+az storage blob list \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  -o table
+```
+
+Just the names:
+
+```bash
+az storage blob list \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --query "[].name" -o tsv
+```
+
+Only under one prefix (the slash-separated names act like folders):
+
+```bash
+az storage blob list \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --prefix "2026-06/" -o table
+```
+
+## Step 6 — Download a file
+
+```bash
+az storage blob download \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --name demo.txt --file ./demo-out.txt
+
+cat ./demo-out.txt
+```
+
+## Step 7 — Upload a whole folder
+
+```bash
+az storage blob upload-batch \
+  --account-name $STG \
+  --destination $CONTAINER \
+  --auth-mode login \
+  --source /path/to/local/folder
+```
+
+This preserves the directory structure under the container. It's **idempotent** — re-running it will skip files that are already there and only upload anything new or changed. Safe to retry if a session drops.
+
+## Step 8 — Large datasets: use `azcopy`
+
+For more than a few GB, the `az storage blob` commands work but `azcopy` is much faster (parallel, resumable):
+
+```bash
+azcopy login --identity      # signs in as the VM, same as az login --identity
+
+azcopy copy "/path/to/local/folder" \
+  "https://$STG.blob.core.windows.net/$CONTAINER/" \
+  --recursive=true
+```
+
+If `azcopy` isn't installed:
+
+```bash
+wget https://aka.ms/downloadazcopy-v10-linux -O /tmp/azcopy.tgz
+tar -xf /tmp/azcopy.tgz --strip-components=1 -C /tmp
+sudo install /tmp/azcopy /usr/local/bin/
+```
+
+For multi-hour transfers, run it in the background so a Guacamole disconnect doesn't kill it:
+
+```bash
+nohup azcopy copy "/path/to/local/folder" \
+  "https://$STG.blob.core.windows.net/$CONTAINER/" --recursive=true \
+  > ~/azcopy.log 2>&1 &
+
+tail -f ~/azcopy.log
+```
+
+## What happens to your data over time
+
+Every blob you upload starts on the **Hot** tier (fastest access, highest cost). A lifecycle policy on the storage account automatically moves it down through cheaper tiers based on the last time the blob was modified:
+
+| Days since last modified | Tier | Behaviour |
+|---|---|---|
+| 0 – 30 | **Hot** | Fastest reads/writes, highest storage cost. |
+| 30 – 90 | **Cool** | Cheaper storage, very slightly higher read cost. Still milliseconds to access. |
+| 90 – 180 | **Cold** | Cheaper still. Still online — milliseconds to access, but higher read cost. |
+| 180+ | **Archive** | Cheapest storage. **Blob is offline** — you must rehydrate it before reading (see below). |
+
+(Exact thresholds may be configured differently in your workspace — check the workspace service Outputs.)
+
+If you know a file should start cheap, you can skip Hot when uploading:
+
+```bash
+az storage blob upload \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login --tier Cool \
+  --file ./oldproject.tar --name oldproject.tar
+```
+
+`--tier` accepts `Hot`, `Cool`, `Cold`, or `Archive`. Be careful with `Archive` — the blob is immediately offline and you'll need to rehydrate it to read.
+
+## Retrieving archived data
+
+A blob that has reached the Archive tier is **offline** — `az storage blob download` will fail with a 409 error. To read it, you have to ask Azure to bring it back online (called **rehydration**):
+
+```bash
+# 1. Trigger rehydration — moves the blob back to Hot (or Cool)
+az storage blob set-tier \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --name big-old-dataset.tar \
+  --tier Hot --rehydrate-priority Standard
+
+# 2. Check progress
+az storage blob show \
+  --account-name $STG --container-name $CONTAINER \
+  --auth-mode login \
+  --name big-old-dataset.tar \
+  --query "{tier:properties.blobTier, status:properties.rehydrationStatus}"
+
+# 3. Once status is "rehydrate-pending-to-hot" → "Hot" you can download as normal.
+```
+
+Rehydration with `Standard` priority can take **up to 15 hours**. `High` priority is faster (typically under 1 hour) but costs more — use it only for blobs under 10 GB.
+
+[Azure docs: Rehydrate an archived blob](https://learn.microsoft.com/azure/storage/blobs/archive-rehydrate-overview).
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---|---|---|
+| `az login --identity` fails: "No identity available" | The VM doesn't have a managed identity (older bundle, or it was disabled). | Ask the workspace owner to enable system-assigned identity on the VM, then redeploy or restart. |
+| `403 AuthorizationPermissionMismatch` on blob operations | The role assignment was just created and hasn't propagated yet, or `Shared Storage Access` was disabled on the VM. | Wait 2–5 minutes for role propagation. If still failing after 10 min, check that `Shared Storage Access` is enabled on the VM user resource — if it isn't, the role assignment is skipped by design. |
+| `403 AuthorizationFailure` | You forgot `--auth-mode login` (it tried key auth, which is disabled), or you're running the command from outside the workspace network. | Add `--auth-mode login` to every `az storage blob …` command. Run from the workspace VM. |
+| `nslookup` returns a public IP (`20.x.x.x`) | You're not on the workspace network — likely your laptop or dev container. | Open the VM via Guacamole and run the commands there. |
+| `az storage blob download` returns 409 `BlobArchived` | The blob has been tiered to Archive and is offline. | Rehydrate it first — see [Retrieving archived data](#retrieving-archived-data). |
+| `azcopy` says it doesn't have permission | You ran `az login --identity` but not `azcopy login --identity`. | Run `azcopy login --identity` once per session. |
+
+## Quick reference
+
+```bash
+# variables
+STG=<your-storage-account-name>
+CONTAINER=archive
+
+# one-time per session
+az login --identity
+
+# common operations
+az storage blob upload   --account-name $STG --container-name $CONTAINER --auth-mode login --name <blob> --file <local>
+az storage blob list     --account-name $STG --container-name $CONTAINER --auth-mode login -o table
+az storage blob download --account-name $STG --container-name $CONTAINER --auth-mode login --name <blob> --file <local>
+az storage blob delete   --account-name $STG --container-name $CONTAINER --auth-mode login --name <blob>
+
+# whole folders
+az storage blob upload-batch --account-name $STG --destination $CONTAINER --auth-mode login --source <folder>
+
+# big data
+azcopy login --identity
+azcopy copy "<folder>" "https://$STG.blob.core.windows.net/$CONTAINER/" --recursive=true
+```

--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -1,8 +1,8 @@
 # API
 httpx==0.25.0
-pytest==7.4.3
-pytest-asyncio==0.21.1
-starlette==0.36.3
+pytest==8.3.3
+pytest-asyncio==0.24.0
+starlette==0.41.3
 pytest-timeout==2.2.0
 pytest-xdist==3.3.1
 backoff==2.2.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
           - Set up of a Virtual Machine: using-tre/tre-for-research/using-vms.md
           - Importing/exporting data with Airlock: using-tre/tre-for-research/importing-exporting-data-airlock.md
           - Reviewing Airlock Requests: using-tre/tre-for-research/review-airlock-request.md
+          - Working with Blob Storage: using-tre/tre-for-research/working-with-blob-storage.md
 
   - Templates and Services: # Docs to highlight and illustrate workspaces, workspace services etc
       - Workspaces:

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-linuxvm
-version: 1.2.14
+version: 1.2.15
 description: "An Azure TRE User Resource Template for Guacamole (Linux)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/role_assignment.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-linuxvm/terraform/role_assignment.tf
@@ -1,0 +1,12 @@
+# Grant the VM's system-assigned managed identity data-plane access to the
+# workspace shared storage account. With this in place, researchers on the VM
+# can authenticate to blob storage with `az login --identity` (no per-user
+# credentials, no Conditional Access on user grant types) and read/write any
+# container on the workspace SA — including the long-term "archive" container
+# with its lifecycle policy.
+resource "azurerm_role_assignment" "vm_storage_blob_data_contributor" {
+  count                = tobool(var.shared_storage_access) ? 1 : 0
+  scope                = data.azurerm_storage_account.stg.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_linux_virtual_machine.linuxvm.identity[0].principal_id
+}

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-service-guacamole-windowsvm
-version: 1.2.13
+version: 1.2.14
 description: "An Azure TRE User Resource Template for Guacamole (Windows 10)"
 dockerfile: Dockerfile.tmpl
 registry: azuretre

--- a/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/role_assignment.tf
+++ b/templates/workspace_services/guacamole/user_resources/guacamole-azure-windowsvm/terraform/role_assignment.tf
@@ -1,0 +1,12 @@
+# Grant the VM's system-assigned managed identity data-plane access to the
+# workspace shared storage account. With this in place, researchers on the VM
+# can authenticate to blob storage with `az login --identity` (no per-user
+# credentials, no Conditional Access on user grant types) and read/write any
+# container on the workspace SA — including the long-term "archive" container
+# with its lifecycle policy.
+resource "azurerm_role_assignment" "vm_storage_blob_data_contributor" {
+  count                = tobool(var.shared_storage_access) ? 1 : 0
+  scope                = data.azurerm_storage_account.stg.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_windows_virtual_machine.windowsvm.identity[0].principal_id
+}

--- a/templates/workspaces/base/parameters.json
+++ b/templates/workspaces/base/parameters.json
@@ -53,6 +53,24 @@
       }
     },
     {
+      "name": "archive_cool_days",
+      "source": {
+        "env": "ARCHIVE_COOL_DAYS"
+      }
+    },
+    {
+      "name": "archive_cold_days",
+      "source": {
+        "env": "ARCHIVE_COLD_DAYS"
+      }
+    },
+    {
+      "name": "archive_archive_days",
+      "source": {
+        "env": "ARCHIVE_ARCHIVE_DAYS"
+      }
+    },
+    {
       "name": "enable_local_debugging",
       "source": {
         "env": "ENABLE_LOCAL_DEBUGGING"

--- a/templates/workspaces/base/porter.yaml
+++ b/templates/workspaces/base/porter.yaml
@@ -1,7 +1,7 @@
 ---
 schemaVersion: 1.0.0
 name: tre-workspace-base
-version: 2.0.3
+version: 2.1.0
 description: "A base Azure TRE workspace"
 dockerfile: Dockerfile.tmpl
 registry: azuretre
@@ -57,6 +57,18 @@ parameters:
   - name: shared_storage_quota
     type: integer
     default: 50
+  - name: archive_cool_days
+    type: integer
+    default: 30
+    description: "Days since last modification before a blob in the archive container moves to the Cool tier."
+  - name: archive_cold_days
+    type: integer
+    default: 90
+    description: "Days since last modification before a blob in the archive container moves to the Cold tier."
+  - name: archive_archive_days
+    type: integer
+    default: 180
+    description: "Days since last modification before a blob in the archive container moves to the Archive tier (offline; requires rehydration)."
   - name: enable_local_debugging
     type: boolean
     default: false
@@ -175,6 +187,9 @@ install:
         location: ${ bundle.parameters.azure_location }
         address_spaces: ${ bundle.parameters.address_spaces }
         shared_storage_quota: ${ bundle.parameters.shared_storage_quota }
+        archive_cool_days: ${ bundle.parameters.archive_cool_days }
+        archive_cold_days: ${ bundle.parameters.archive_cold_days }
+        archive_archive_days: ${ bundle.parameters.archive_archive_days }
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }
@@ -220,6 +235,9 @@ upgrade:
         location: ${ bundle.parameters.azure_location }
         address_spaces: ${ bundle.parameters.address_spaces }
         shared_storage_quota: ${ bundle.parameters.shared_storage_quota }
+        archive_cool_days: ${ bundle.parameters.archive_cool_days }
+        archive_cold_days: ${ bundle.parameters.archive_cold_days }
+        archive_archive_days: ${ bundle.parameters.archive_archive_days }
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }
@@ -289,6 +307,9 @@ uninstall:
         location: ${ bundle.parameters.azure_location }
         address_spaces: ${ bundle.parameters.address_spaces }
         shared_storage_quota: ${ bundle.parameters.shared_storage_quota }
+        archive_cool_days: ${ bundle.parameters.archive_cool_days }
+        archive_cold_days: ${ bundle.parameters.archive_cold_days }
+        archive_archive_days: ${ bundle.parameters.archive_archive_days }
         enable_local_debugging: ${ bundle.parameters.enable_local_debugging }
         register_aad_application: ${ bundle.parameters.register_aad_application }
         create_aad_groups: ${ bundle.parameters.create_aad_groups }

--- a/templates/workspaces/base/template_schema.json
+++ b/templates/workspaces/base/template_schema.json
@@ -45,6 +45,27 @@
         "ZRS"
       ]
     },
+    "archive_cool_days": {
+      "type": "integer",
+      "title": "Archive container: days until Cool tier",
+      "description": "Days after last modification before a blob in the workspace archive container moves to the Cool tier.",
+      "default": 30,
+      "updateable": true
+    },
+    "archive_cold_days": {
+      "type": "integer",
+      "title": "Archive container: days until Cold tier",
+      "description": "Days after last modification before a blob in the workspace archive container moves to the Cold tier. Must be greater than 'Archive container: days until Cool tier'.",
+      "default": 90,
+      "updateable": true
+    },
+    "archive_archive_days": {
+      "type": "integer",
+      "title": "Archive container: days until Archive tier",
+      "description": "Days after last modification before a blob in the workspace archive container moves to the Archive tier. Blobs on the Archive tier are offline and must be rehydrated before reading. Must be greater than 'Archive container: days until Cold tier'.",
+      "default": 180,
+      "updateable": true
+    },
     "address_space_size": {
       "type": "string",
       "title": "Address space size",

--- a/templates/workspaces/base/terraform/outputs.tf
+++ b/templates/workspaces/base/terraform/outputs.tf
@@ -2,6 +2,14 @@ output "workspace_resource_name_suffix" {
   value = local.workspace_resource_name_suffix
 }
 
+output "storage_account_name" {
+  value = azurerm_storage_account.stg.name
+}
+
+output "archive_container_name" {
+  value = azurerm_storage_container.archive.name
+}
+
 # The following outputs are dependent on an Automatic AAD Workspace Application Registration.
 # If we are not creating an App Reg we simple pass back the same values that were already created
 # This is necessary so that we don't delete workspace properties

--- a/templates/workspaces/base/terraform/storage.tf
+++ b/templates/workspaces/base/terraform/storage.tf
@@ -62,6 +62,44 @@ resource "azurerm_storage_container" "stgcontainer" {
   ]
 }
 
+# Long-term cold/archive container for workspace data that researchers want to
+# retain but rarely access. Lifecycle policy below tiers blobs down to Cool,
+# Cold, then Archive based on the configured thresholds.
+resource "azurerm_storage_container" "archive" {
+  name                  = "archive"
+  storage_account_name  = azurerm_storage_account.stg.name
+  container_access_type = "private"
+
+  depends_on = [
+    azurerm_private_endpoint.stgblobpe,
+    azurerm_storage_account_network_rules.stgrules
+  ]
+}
+
+resource "azurerm_storage_management_policy" "archive_lifecycle" {
+  storage_account_id = azurerm_storage_account.stg.id
+
+  rule {
+    name    = "tier-down-archive-container"
+    enabled = true
+
+    filters {
+      prefix_match = ["${azurerm_storage_container.archive.name}/"]
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_modification_greater_than    = var.archive_cool_days
+        tier_to_cold_after_days_since_modification_greater_than    = var.archive_cold_days
+        tier_to_archive_after_days_since_modification_greater_than = var.archive_archive_days
+      }
+    }
+  }
+
+  depends_on = [azurerm_storage_container.archive]
+}
+
 resource "azurerm_storage_account_network_rules" "stgrules" {
   storage_account_id = azurerm_storage_account.stg.id
 

--- a/templates/workspaces/base/terraform/variables.tf
+++ b/templates/workspaces/base/terraform/variables.tf
@@ -139,3 +139,21 @@ variable "storage_account_redundancy" {
   default     = "GRS"
   description = "The redundancy option for the storage account in the workspace: GRS (Geo-Redundant Storage) or ZRS (Zone-Redundant Storage)."
 }
+
+variable "archive_cool_days" {
+  type        = number
+  default     = 30
+  description = "Days since last modification before a blob in the archive container is moved to the Cool tier."
+}
+
+variable "archive_cold_days" {
+  type        = number
+  default     = 90
+  description = "Days since last modification before a blob in the archive container is moved to the Cold tier. Must be greater than archive_cool_days."
+}
+
+variable "archive_archive_days" {
+  type        = number
+  default     = 180
+  description = "Days since last modification before a blob in the archive container is moved to the Archive tier (offline; requires rehydration to read). Must be greater than archive_cold_days."
+}


### PR DESCRIPTION
Closes #317. Research projects often ingest multiple TB of data at the start, process it once, and then rarely touch it again — but deleting it forces a costly re-import if anyone needs to go back to it, and keeping it on the workspace shared file-share (Hot tier) is expensive. This PR gives every workspace a long-term `archive` blob container with an auto-tiering lifecycle policy (Hot → Cool → Cold → Archive, with configurable thresholds) on the existing shared storage account, so researchers can drop seldom-accessed datasets in and storage cost decays on its own; the data remains retrievable (Archive blobs need rehydration, but they aren't gone). The `guacamole-azure-linuxvm` and `guacamole-azure-windowsvm` user-resource templates now auto-grant the VM's system-assigned managed identity `Storage Blob Data Contributor` on the workspace SA (gated by the existing `shared_storage_access` flag), so researchers sign in on a workspace VM with `az login --identity` and read/write the `archive` container with no per-user credentials and no workspace-owner role-grant step. Bumps base workspace 2.0.3 → 2.1.0, linuxvm 1.2.14 → 1.2.15, windowsvm 1.2.13 → 1.2.14. A new researcher-facing page at `docs/using-tre/tre-for-research/working-with-blob-storage.md` covers the end-to-end VM-side flow, and `deploy-archive-refactor.sh` wraps the three bundle publishes and prints the manual TRE UI upgrade steps. The separate commit fixing `e2e_tests/requirements.txt` aligns the pytest pin with `api_app/requirements-dev.txt` to unblock fresh dev container builds (pip 23.3.1's resolver was rejecting the prior 7.4.3 / 8.3.3 mismatch).